### PR TITLE
Bugfixes and add user layer

### DIFF
--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -256,7 +256,7 @@ function textStyle(textsymbolizer, feature, type) {
  * @return ol.style.Style or array of it
  */
 export default function OlStyler(GeometryStyles, feature) {
-  const type = feature.getGeometry().getType ? feature.getGeometry().getType() : feature.geometry.type;
+  const type = feature.getGeometry ? feature.getGeometry().getType ? feature.getGeometry().getType() : feature.geometry.type : feature.geometry.type;
   const {
     polygon, line, point, text,
   } = GeometryStyles;

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -237,7 +237,6 @@ function textStyle(textsymbolizer, properties, feature, type) {
           color: halo.fillOpacity && halo.fill && halo.fill.slice(0, 1) === '#' ? hexToRGB(halo.fill, halo.fillOpacity) : halo.fill,
           // wrong position width radius equal to 2 or 4
           width: (haloRadius === 2 || haloRadius === 4 ? haloRadius - 0.00001 : haloRadius) * 2,
-
         }) : undefined,
         fill: new Fill({
           color: fill.fillOpacity && fill.fill && fill.fill.slice(0, 1) === '#' ? hexToRGB(fill.fill, fill.fillOpacity) : fill.fill,

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -255,7 +255,12 @@ function textStyle(textsymbolizer, properties, feature, type) {
  * @return ol.style.Style or array of it
  */
 export default function OlStyler(GeometryStyles, type, feature) {
-  const properties = feature.getProperties();
+  let properties;
+  if(feature.getProperties) {
+    properties = feature.getProperties();
+  } else {
+    properties = feature.properties;
+  }
   const {
     polygon, line, point, text,
   } = GeometryStyles;

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -256,7 +256,8 @@ function textStyle(textsymbolizer, feature, type) {
  * @return ol.style.Style or array of it
  */
 export default function OlStyler(GeometryStyles, feature) {
-  const type = feature.getGeometry ? feature.getGeometry().getType ? feature.getGeometry().getType() : feature.geometry.type : feature.geometry.type;
+  const geometry = feature.getGeometry ? feature.getGeometry() : feature.geometry;
+  const type = geometry.getType ? feature.getType() : feature.geometry.type;
   const {
     polygon, line, point, text,
   } = GeometryStyles;

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -256,10 +256,10 @@ function textStyle(textsymbolizer, properties, feature, type) {
  */
 export default function OlStyler(GeometryStyles, type, feature) {
   let properties;
-  if(feature.getProperties) {
+  if (feature.getProperties) {
     properties = feature.getProperties();
   } else {
-    properties = feature.properties;
+    let { properties } = feature;
   }
   const {
     polygon, line, point, text,

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -99,7 +99,7 @@ function pointStyle(pointsymbolizer) {
     } else {
       stroke = undefined;
     }
-    const radius = style.size || 10;
+    const radius = Number(style.size) || 10;
     switch (style.mark.wellknownname) {
       case 'circle':
         return new Style({
@@ -190,7 +190,8 @@ function pointStyle(pointsymbolizer) {
  * @param {string} type geometry type, @see {@link http://geojson.org|geojson}
  * @return {object} openlayers style
  */
-function textStyle(textsymbolizer, properties, feature, type) {
+function textStyle(textsymbolizer, feature, type) {
+  const properties = feature.getProperties ? feature.getProperties() : feature.properties;
   if (textsymbolizer && textsymbolizer.label) {
     const parseText = {
       text: part => part,
@@ -254,8 +255,8 @@ function textStyle(textsymbolizer, properties, feature, type) {
  * @param {object} feature geojson feature, @see {@link http://geojson.org|geojson} Changed in version 0.0.4
  * @return ol.style.Style or array of it
  */
-export default function OlStyler(GeometryStyles, type, feature) {
-  const properties = feature.getProperties ? feature.getProperties() : feature.properties;
+export default function OlStyler(GeometryStyles, feature) {
+  const type = feature.getGeometry().getType ? feature.getGeometry().getType() : feature.geometry.type;
   const {
     polygon, line, point, text,
   } = GeometryStyles;
@@ -267,7 +268,7 @@ export default function OlStyler(GeometryStyles, type, feature) {
         styles.push(polygonStyle(polygon[i]));
       }
       for (let j = 0; j < text.length; j += 1) {
-        styles.push(textStyle(text[j], properties, feature, 'polygon'));
+        styles.push(textStyle(text[j], feature, 'polygon'));
       }
       break;
     case 'LineString':
@@ -276,7 +277,7 @@ export default function OlStyler(GeometryStyles, type, feature) {
         styles.push(lineStyle(line[j]));
       }
       for (let j = 0; j < text.length; j += 1) {
-        styles.push(textStyle(text[j], properties, feature, 'line'));
+        styles.push(textStyle(text[j], feature, 'line'));
       }
       break;
     case 'Point':
@@ -285,7 +286,7 @@ export default function OlStyler(GeometryStyles, type, feature) {
         styles.push(pointStyle(point[j]));
       }
       for (let j = 0; j < text.length; j += 1) {
-        styles.push(textStyle(text[j], properties, feature, 'point'));
+        styles.push(textStyle(text[j], feature, 'point'));
       }
       break;
     default:

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -90,7 +90,7 @@ function pointStyle(pointsymbolizer) {
     fill = new Fill({
       color: fillColor,
     });
-    if (stroke && !(stroke.css.strokeWidth == 0)) {
+    if (stroke && !(Number(stroke.css.strokeWidth) === 0)) {
       const { stroke: cssStroke, strokeWidth: cssStrokeWidth } = stroke.css;
       stroke = new Stroke({
         color: cssStroke || 'black',
@@ -194,7 +194,7 @@ function textStyle(textsymbolizer, properties, feature, type) {
   if (textsymbolizer && textsymbolizer.label) {
     const parseText = {
       text: part => part,
-      propertyname: (part, properties = {}) => properties[part] || '',
+      propertyname: (part, props = {}) => props[part] || '',
     };
     const label = textsymbolizer.label.length ? textsymbolizer.label : [textsymbolizer.label];
 
@@ -225,12 +225,12 @@ function textStyle(textsymbolizer, properties, feature, type) {
 
     return new Style({
       text: new Text({
-        text: text,
+        text,
         font: `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`,
         offsetX: Number(offsetX),
         offsetY: Number(offsetY),
-        rotation: rotation,
-        placement: placement,
+        rotation,
+        placement,
         textAlign: 'center',
         textBaseline: 'middle',
         stroke: textsymbolizer.halo ? new Stroke({

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -255,12 +255,7 @@ function textStyle(textsymbolizer, properties, feature, type) {
  * @return ol.style.Style or array of it
  */
 export default function OlStyler(GeometryStyles, type, feature) {
-  let properties;
-  if (feature.getProperties) {
-    properties = feature.getProperties();
-  } else {
-    let { properties } = feature;
-  }
+  const properties = feature.getProperties ? feature.getProperties() : feature.properties;
   const {
     polygon, line, point, text,
   } = GeometryStyles;

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -257,7 +257,7 @@ function textStyle(textsymbolizer, feature, type) {
  */
 export default function OlStyler(GeometryStyles, feature) {
   const geometry = feature.getGeometry ? feature.getGeometry() : feature.geometry;
-  const type = geometry.getType ? feature.getType() : feature.geometry.type;
+  const type = geometry.getType ? geometry.getType() : geometry.type;
   const {
     polygon, line, point, text,
   } = GeometryStyles;

--- a/src/Reader.js
+++ b/src/Reader.js
@@ -183,6 +183,9 @@ const parsers = Object.assign(
     NamedLayer: (element, obj) => {
       addPropArray(element, obj, 'layers');
     },
+    UserLayer: (element, obj) => {
+      addPropArray(element, obj, 'layers');
+    },
     UserStyle: (element, obj) => {
       obj.styles = obj.styles || [];
       const style = {

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -34,23 +34,23 @@ describe('create ol style object from styledescription', () => {
   };
 
   it('returns array', () => {
-    const style = OlStyler(styleDescription, 'Polygon', getFeature('Polygon'));
+    const style = OlStyler(styleDescription, getFeature('Polygon'));
     expect(style).to.be.an.array;
   });
   it('returns object with polygon style', () => {
-    const style = OlStyler(styleDescription, 'Polygon', getFeature('Polygon'));
+    const style = OlStyler(styleDescription, getFeature('Polygon'));
     expect(style['0']).to.be.an.instanceof(Style);
   });
   it('returns object with polygon fill', () => {
-    const style = OlStyler(styleDescription, 'Polygon', getFeature('Polygon'));
+    const style = OlStyler(styleDescription, getFeature('Polygon'));
     expect(style['0'].getFill().getColor()).to.equal('blue');
   });
   it('returns object linestring style', () => {
-    const style = OlStyler(styleDescription, 'LineString', getFeature('LineString'));
+    const style = OlStyler(styleDescription, getFeature('LineString'));
     expect(style['0']).to.be.an.instanceof(Style);
   });
   it('returns object with polygon fill', () => {
-    const style = OlStyler(styleDescription, 'LineString', getFeature('LineString'));
+    const style = OlStyler(styleDescription, getFeature('LineString'));
     expect(style['0'].getStroke().getColor()).to.equal('red');
   });
 });
@@ -76,11 +76,11 @@ describe('creates point style', () => {
     ],
   };
   it('returns array', () => {
-    const style = OlStyler(styleDescription, 'Point', getFeature('Point'));
+    const style = OlStyler(styleDescription, getFeature('Point'));
     expect(style).to.be.an.array;
   });
   it('returns style', () => {
-    const style = OlStyler(styleDescription, 'Point', getFeature('Point'));
+    const style = OlStyler(styleDescription, getFeature('Point'));
     expect(style['0']).to.be.an.instanceOf(Style);
   });
 });

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -34,23 +34,23 @@ describe('create ol style object from styledescription', () => {
   };
 
   it('returns array', () => {
-    const style = OlStyler(styleDescription, getFeature('Polygon'));
+    const style = OlStyler(styleDescription, 'Polygon', getFeature('Polygon'));
     expect(style).to.be.an.array;
   });
   it('returns object with polygon style', () => {
-    const style = OlStyler(styleDescription, getFeature('Polygon'));
+    const style = OlStyler(styleDescription, 'Polygon', getFeature('Polygon'));
     expect(style['0']).to.be.an.instanceof(Style);
   });
   it('returns object with polygon fill', () => {
-    const style = OlStyler(styleDescription, getFeature('Polygon'));
+    const style = OlStyler(styleDescription, 'Polygon', getFeature('Polygon'));
     expect(style['0'].getFill().getColor()).to.equal('blue');
   });
   it('returns object linestring style', () => {
-    const style = OlStyler(styleDescription, getFeature('LineString'));
+    const style = OlStyler(styleDescription, 'LineString', getFeature('LineString'));
     expect(style['0']).to.be.an.instanceof(Style);
   });
   it('returns object with polygon fill', () => {
-    const style = OlStyler(styleDescription, getFeature('LineString'));
+    const style = OlStyler(styleDescription, 'LineString', getFeature('LineString'));
     expect(style['0'].getStroke().getColor()).to.equal('red');
   });
 });
@@ -76,11 +76,11 @@ describe('creates point style', () => {
     ],
   };
   it('returns array', () => {
-    const style = OlStyler(styleDescription, getFeature('Point'));
+    const style = OlStyler(styleDescription, 'Point', getFeature('Point'));
     expect(style).to.be.an.array;
   });
   it('returns style', () => {
-    const style = OlStyler(styleDescription, getFeature('Point'));
+    const style = OlStyler(styleDescription, 'Point', getFeature('Point'));
     expect(style['0']).to.be.an.instanceOf(Style);
   });
 });


### PR DESCRIPTION
We fixed some bugs that appeared when we pulled the new textsymbolizer and tried using it.

At the stroke implementation for geometry type 'Point', we changed that Stroke is just set, if the width is bigger than 0.
Also, the created halo (stroke of Text-Style) in the textStyle-function is just set, if it is actually existent.

We had to do those both changes, because visual appearence did not match with the given SLD entrys.

The width of the halo also must be multiplied by 2, because u need the stroke on both sides of the letter, not just on one.

Other things were just typos or bugs we found while implementing.

Greets,
Alex