### PR TITLE
Use WeakMap to cache OL style instances

### DIFF
--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -335,6 +335,17 @@ const cachedPointStyle = memoize(pointStyle);
 const cachedLineStyle = memoize(lineStyle);
 const cachedPolygonStyle = memoize(polygonStyle);
 
+const defaultStyles = [
+  new Style({
+    image: new Circle({
+      radius: 2,
+      fill: new Fill({
+        color: 'blue',
+      }),
+    }),
+  }),
+];
+
 /**
  * Create openlayers style
  * @example OlStyler(getGeometryStyles(rules), geojson.geometry.type);
@@ -379,16 +390,7 @@ export default function OlStyler(GeometryStyles, feature) {
       }
       break;
     default:
-      styles = [
-        new Style({
-          image: new Circle({
-            radius: 2,
-            fill: new Fill({
-              color: 'blue',
-            }),
-          }),
-        }),
-      ];
+      styles = defaultStyles;
   }
   return styles;
 }

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -301,6 +301,40 @@ function textStyle(textsymbolizer, feature, type) {
   return new Style({});
 }
 
+// Create memoized versions of the style converters.
+// They use a WeakMap to return the same OL style object if the symbolizer is the same.
+// Note: this only works for constant symbolizers!
+// Todo: find a smart way to optimize text symbolizers.
+
+/**
+ * Function to memoize style conversion functions that convert sld symbolizers to OpenLayers style instances.
+ * The memoized version of the style converter returns the same OL style instance if the symbolizer is the same object.
+ * Uses a WeakMap internally.
+ * Note: This only works for constant symbolizers.
+ * Note: Text symbolizers depend on the feature property and the geometry type, these cannot be cached in this way.
+ * @param {Function} styleFunction Function that accepts a single symbolizer object and returns the corresponding OpenLayers style object.
+ * @returns {Function} The memoized function of the style conversion function.
+ */
+function memoize(styleFunction) {
+  const styleCache = new WeakMap();
+
+  return symbolizer => {
+    let olStyle = styleCache.get(symbolizer);
+
+    if (!olStyle) {
+      olStyle = styleFunction(symbolizer);
+      styleCache.set(symbolizer, olStyle);
+    }
+
+    return olStyle;
+  };
+}
+
+// Memoized versions of point, line and polygon style converters.
+const cachedPointStyle = memoize(pointStyle);
+const cachedLineStyle = memoize(lineStyle);
+const cachedPolygonStyle = memoize(polygonStyle);
+
 /**
  * Create openlayers style
  * @example OlStyler(getGeometryStyles(rules), geojson.geometry.type);
@@ -320,7 +354,7 @@ export default function OlStyler(GeometryStyles, feature) {
     case 'Polygon':
     case 'MultiPolygon':
       for (let i = 0; i < polygon.length; i += 1) {
-        styles.push(polygonStyle(polygon[i]));
+        styles.push(cachedPolygonStyle(polygon[i]));
       }
       for (let j = 0; j < text.length; j += 1) {
         styles.push(textStyle(text[j], feature, 'polygon'));
@@ -329,7 +363,7 @@ export default function OlStyler(GeometryStyles, feature) {
     case 'LineString':
     case 'MultiLineString':
       for (let j = 0; j < line.length; j += 1) {
-        styles.push(lineStyle(line[j]));
+        styles.push(cachedLineStyle(line[j]));
       }
       for (let j = 0; j < text.length; j += 1) {
         styles.push(textStyle(text[j], feature, 'line'));
@@ -338,7 +372,7 @@ export default function OlStyler(GeometryStyles, feature) {
     case 'Point':
     case 'MultiPoint':
       for (let j = 0; j < point.length; j += 1) {
-        styles.push(pointStyle(point[j]));
+        styles.push(cachedPointStyle(point[j]));
       }
       for (let j = 0; j < text.length; j += 1) {
         styles.push(textStyle(text[j], feature, 'point'));


### PR DESCRIPTION
Creating new OL style instances has a noticeable performance overhead, so instead of creating a new OL Style instance within each invocation of OlStyler, use a WeakMap to return the same OL style instance if the SLD symbolizer object is the same.

This only happens for point, polygon, and line symbolizers, because they are constant and do not depend on feature attributes. Text symbolizers are not cached in this manner, because they depend on feature properties.