### PR TITLE
Optimize filterSelector performance

### DIFF
--- a/src/Filter.js
+++ b/src/Filter.js
@@ -1,21 +1,19 @@
-function propertyIsLessThan(comparison, feature, getProperty) {
-  const value = getProperty(feature, comparison.propertyname);
+function propertyIsLessThan(comparison, value) {
   return (
     // Todo: support string comparison as well
     typeof value !== 'undefined' && Number(value) < Number(comparison.literal)
   );
 }
 
-function propertyIsBetween(comparison, feature, getProperty) {
+function propertyIsBetween(comparison, value) {
   // Todo: support string comparison as well
   const lowerBoundary = Number(comparison.lowerboundary);
   const upperBoundary = Number(comparison.upperboundary);
-  const value = Number(getProperty(feature, comparison.propertyname));
-  return value >= lowerBoundary && value <= upperBoundary;
+  const numericValue = Number(value);
+  return numericValue >= lowerBoundary && numericValue <= upperBoundary;
 }
 
-function propertyIsEqualTo(comparison, feature, getProperty) {
-  const value = getProperty(feature, comparison.propertyname);
+function propertyIsEqualTo(comparison, value) {
   if (typeof value === 'undefined') {
     return false;
   }
@@ -27,13 +25,12 @@ function propertyIsEqualTo(comparison, feature, getProperty) {
  * A very basic implementation of a PropertyIsLike by converting match pattern to a regex.
  * @private
  * @param {object} comparison filter object for operator 'propertyislike'
- * @param {object} feature Feature object.
+ * @param {string|number} value Feature property value.
  * @param {object} getProperty A function with parameters (feature, propertyName) to extract
  * the value of a property from a feature.
  */
-function propertyIsLike(comparison, feature, getProperty) {
+function propertyIsLike(comparison, value) {
   const pattern = comparison.literal;
-  const value = getProperty(feature, comparison.propertyname);
 
   if (typeof value === 'undefined') {
     return false;
@@ -76,32 +73,34 @@ function propertyIsLike(comparison, feature, getProperty) {
  * @return {bool}  does feature fullfill comparison
  */
 function doComparison(comparison, feature, getProperty) {
+  const value = getProperty(feature, comparison.propertyname);
+
   switch (comparison.operator) {
     case 'propertyislessthan':
-      return propertyIsLessThan(comparison, feature, getProperty);
+      return propertyIsLessThan(comparison, value);
     case 'propertyisequalto':
-      return propertyIsEqualTo(comparison, feature, getProperty);
+      return propertyIsEqualTo(comparison, value);
     case 'propertyislessthanorequalto':
       return (
-        propertyIsEqualTo(comparison, feature, getProperty) ||
-        propertyIsLessThan(comparison, feature, getProperty)
+        propertyIsEqualTo(comparison, value) ||
+        propertyIsLessThan(comparison, value)
       );
     case 'propertyisnotequalto':
-      return !propertyIsEqualTo(comparison, feature, getProperty);
+      return !propertyIsEqualTo(comparison, value);
     case 'propertyisgreaterthan':
       return (
-        !propertyIsLessThan(comparison, feature, getProperty) &&
-        !propertyIsEqualTo(comparison, feature, getProperty)
+        !propertyIsLessThan(comparison, value) &&
+        !propertyIsEqualTo(comparison, value)
       );
     case 'propertyisgreaterthanorequalto':
       return (
-        !propertyIsLessThan(comparison, feature, getProperty) ||
-        propertyIsEqualTo(comparison, feature, getProperty)
+        !propertyIsLessThan(comparison, value) ||
+        propertyIsEqualTo(comparison, value)
       );
     case 'propertyisbetween':
-      return propertyIsBetween(comparison, feature, getProperty);
+      return propertyIsBetween(comparison, value);
     case 'propertyislike':
-      return propertyIsLike(comparison, feature, getProperty);
+      return propertyIsLike(comparison, value);
     default:
       throw new Error(`Unkown comparison operator ${comparison.operator}`);
   }

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -405,12 +405,13 @@ function getOlFeatureId(feature) {
 }
 
 /**
- * Extract properties object from an OpenLayers Feature.
+ * Extract a property value from an OpenLayers Feature.
  * @param {Feature} feature {@link https://openlayers.org/en/latest/apidoc/module-ol_Feature-Feature.html|ol/Feature}
- * @returns {object} Feature properties object.
+ * @param {string} propertyName The name of the feature property to read.
+ * @returns {object} Property value.
  */
-function getOlFeatureProperties(feature) {
-  return feature.getProperties();
+function getOlFeatureProperty(feature, propertyName) {
+  return feature.get(propertyName);
 }
 
 /**
@@ -433,7 +434,7 @@ export function createOlStyleFunction(featureTypeStyle, options = {}) {
 
     // Determine applicable style rules for the feature, taking feature properties and current resolution into account.
     const rules = getRules(featureTypeStyle, feature, resolution, {
-      getProperties: getOlFeatureProperties,
+      getProperty: getOlFeatureProperty,
       getFeatureId: getOlFeatureId,
     });
 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -51,7 +51,8 @@ export function getStyle(layer, name) {
  * @param  {FeatureTypeStyle} featureTypeStyle
  * @param  {object} feature geojson
  * @param  {number} resolution m/px
- * @param  {Function} options.getProperties An optional function that can be used to extract properties from a feature.
+ * @param  {Function} options.getProperty An optional function with parameters (feature, propertyName)
+ * that can be used to extract a property value from a feature.
  * When not given, properties are read from feature.properties directly.Error
  * @param  {Function} options.getFeatureId An optional function to extract the feature id from a feature.Error
  * When not given, feature id is read from feature.id.

--- a/test/Filter.test.js
+++ b/test/Filter.test.js
@@ -392,7 +392,7 @@ describe('Custom property extraction', () => {
     };
 
     const result = filterSelector(filter, myFeature, {
-      getProperties: feature => feature.getAttributes(),
+      getProperty: (feature, propertyName) => feature.getAttributes()[propertyName],
     });
 
     expect(result).to.be.false;
@@ -418,7 +418,7 @@ describe('Custom property extraction', () => {
     };
 
     const result = filterSelector(filter, myFeature, {
-      getProperties: feature => feature.getAttributes(),
+      getProperty: (feature, propertyName) => feature.getAttributes()[propertyName],
     });
 
     expect(result).to.be.true;


### PR DESCRIPTION
The filter test function tests a filter object against a feature's properties object. In OpenLayers it's (much!) faster to read a specific feature property directly than to get a feature's properties and accessing the property you want. This is, because OpenLayers feature.getProperties() uses Object.assign under the hood, while direct property access reads from the feature property object directly.

Therefore, the filterSelector function has been changed to use a getProperty function instead of a getProperties function.