### PR TITLE
Cache externalgraphic icons

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -58,6 +58,9 @@
                             districts</a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link {% if page.title == 'Flags of Benelux countries' %}active{% endif %}" href="benelux.html">Flags of the Benelux</a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link {% if page.title == 'API' %}active{% endif %}" href="api.html">api
                             docs</a>
                     </li>

--- a/docs/assets/benelux.js
+++ b/docs/assets/benelux.js
@@ -48,6 +48,7 @@ map.addControl(new ol.control.MousePosition());
  */
 function applySLD(vectorLayer, text) {
   const sldObject = SLDReader.Reader(text);
+  // for debugging
   window.sldObject = sldObject;
   const sldLayer = SLDReader.getLayer(sldObject);
   const style = SLDReader.getStyle(sldLayer, 'flags_benelux');

--- a/docs/assets/benelux.js
+++ b/docs/assets/benelux.js
@@ -1,0 +1,74 @@
+/* global ol SLDReader CodeMirror */
+// the xml editor
+const editor = CodeMirror.fromTextArea(document.getElementById('sld'), {
+  lineNumbers: true,
+  lineWrapping: true,
+  mode: 'xml',
+});
+
+const vectorSource = new ol.source.Vector({
+  format: new ol.format.GeoJSON(),
+  url: 'assets/benelux.json',
+  strategy: ol.loadingstrategy.all,
+});
+
+const vector = new ol.layer.Vector({
+  source: vectorSource,
+  style: new ol.style.Style({
+    image: new ol.style.Circle({
+      radius: 8,
+      fill: new ol.style.Fill({
+        color: 'gray',
+        fillOpacity: 0.7,
+      }),
+    }),
+  }),
+});
+
+const map = new ol.Map({
+  layers: [
+    new ol.layer.Tile({
+      source: new ol.source.OSM(),
+    }),
+    vector,
+  ],
+  target: document.getElementById('olmap'),
+  view: new ol.View({
+    center: [584891.9698102517, 6734386.479226833],
+    maxZoom: 19,
+    zoom: 6,
+  }),
+});
+map.addControl(new ol.control.MousePosition());
+
+/**
+ * @param {object} vector layer
+ * @param {string} text the xml text
+ * apply sld
+ */
+function applySLD(vectorLayer, text) {
+  const sldObject = SLDReader.Reader(text);
+  window.sldObject = sldObject;
+  const sldLayer = SLDReader.getLayer(sldObject);
+  const style = SLDReader.getStyle(sldLayer, 'flags_benelux');
+  const featureTypeStyle = style.featuretypestyles[0];
+
+  vectorLayer.setStyle(SLDReader.createOlStyleFunction(featureTypeStyle, {
+    imageLoadedCallback: () => {
+      // Signal OpenLayers to redraw the layer when an image icon has loaded.
+      // On redraw, the updated symbolizer with the correct image scale will be used to draw the icon.
+      vectorLayer.changed();
+    },
+  }));
+}
+
+fetch('assets/sld-benelux.xml')
+  .then(response => response.text())
+  .then(text => editor.setValue(text));
+
+/**
+ * update map if sld is edited
+ */
+editor.on('change', cm => {
+  applySLD(vector, cm.getValue());
+});

--- a/docs/assets/benelux.json
+++ b/docs/assets/benelux.json
@@ -1,0 +1,35 @@
+{
+  "type": "FeatureCollection",
+  "crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
+  "features": [{
+    "type": "Feature",
+    "id": "be",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [509600, 6575000]
+    },
+    "properties": {
+      "countrycode": "be"
+    }
+  },{
+    "type": "Feature",
+    "id": "lu",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [679600, 6400000]
+    },
+    "properties": {
+      "countrycode": "lu"
+    }
+  },{
+    "type": "Feature",
+    "id": "nl",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [616000, 6800000]
+    },
+    "properties": {
+      "countrycode": "nl"
+    }
+  }]
+}

--- a/docs/assets/sld-benelux.xml
+++ b/docs/assets/sld-benelux.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sld:StyledLayerDescriptor xmlns="http://www.opengis.net/sld" 
+  xmlns:sld="http://www.opengis.net/sld" 
+  xmlns:ogc="http://www.opengis.net/ogc" 
+  xmlns:gml="http://www.opengis.net/gml" 
+  xmlns:xlink="http://www.w3.org/1999/xlink" version="1.0.0">
+  <NamedLayer>
+    <sld:Name>flags_benelux</sld:Name>
+    <UserStyle>
+      <sld:Name>flags_benelux</sld:Name>
+      <sld:FeatureTypeStyle>
+        <sld:Rule>
+          <sld:Name>nl</sld:Name>
+          <sld:Description>
+            <sld:Title>The Netherlands</sld:Title>
+          </sld:Description>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:PropertyIsEqualTo>
+              <ogc:PropertyName>countrycode</ogc:PropertyName>
+              <ogc:Literal>nl</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <sld:PointSymbolizer>
+            <sld:Graphic>
+              <sld:ExternalGraphic>
+                <sld:OnlineResource xlink:type="simple" xlink:href="https://www.countryflags.io/nl/shiny/48.png"/>
+                <sld:Format>image/png</sld:Format>
+              </sld:ExternalGraphic>
+              <sld:Size>24</sld:Size>
+            </sld:Graphic>>
+          </sld:PointSymbolizer>
+        </sld:Rule>
+        <sld:Rule>
+          <sld:Name>be</sld:Name>
+          <sld:Description>
+            <sld:Title>Belgium</sld:Title>
+          </sld:Description>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:PropertyIsEqualTo>
+              <ogc:PropertyName>countrycode</ogc:PropertyName>
+              <ogc:Literal>be</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <sld:PointSymbolizer>
+            <sld:Graphic>
+              <sld:ExternalGraphic>
+                <sld:OnlineResource xlink:type="simple" xlink:href="https://www.countryflags.io/be/shiny/48.png"/>
+                <sld:Format>image/png</sld:Format>
+              </sld:ExternalGraphic>
+              <sld:Size>24</sld:Size>
+            </sld:Graphic>
+          </sld:PointSymbolizer>
+        </sld:Rule>
+        <sld:Rule>
+          <sld:Name>lu</sld:Name>
+          <sld:Description>
+            <sld:Title>Luxembourg</sld:Title>
+          </sld:Description>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:PropertyIsEqualTo>
+              <ogc:PropertyName>countrycode</ogc:PropertyName>
+              <ogc:Literal>lu</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <sld:PointSymbolizer>
+            <sld:Graphic>
+              <sld:ExternalGraphic>
+                <sld:OnlineResource xlink:type="simple" xlink:href="https://www.countryflags.io/lu/shiny/48.png"/>
+                <sld:Format>image/png</sld:Format>
+              </sld:ExternalGraphic>
+              <sld:Size>24</sld:Size>
+            </sld:Graphic>
+          </sld:PointSymbolizer>
+        </sld:Rule>
+      </sld:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</sld:StyledLayerDescriptor>

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -751,7 +751,7 @@
   /**
    * Go through all rules with an external graphic matching the image url
    * and update the __loadingState metadata for the symbolizers with the new imageLoadState.
-   * This action replacec symbolizers with new symbolizers if they get a new __loadingState.
+   * This action replaces symbolizers with new symbolizers if they get a new __loadingState.
    * @param {object} featureTypeStyle A feature type style object.
    * @param {string} imageUrl The image url.
    * @param {string} imageLoadState One of 'IMAGE_LOADING', 'IMAGE_LOADED', 'IMAGE_ERROR'.

--- a/docs/benelux.html
+++ b/docs/benelux.html
@@ -6,6 +6,7 @@ title: Flags of Benelux countries
   <div class="col-md-12">
     <h2 class="pt-3">Point symbolizers with ExternalGraphic</h2>
     <p>This example requires an up to date browser!</p>
+    <p><a href="assets/benelux.js">View code</a></p>
   </div>
 </div>
 <div class="row">

--- a/docs/benelux.html
+++ b/docs/benelux.html
@@ -1,0 +1,25 @@
+---
+layout: default
+title: Flags of Benelux countries
+---
+<div class="row">
+  <div class="col-md-12">
+    <h2 class="pt-3">Point symbolizers with ExternalGraphic</h2>
+    <p>This example requires an up to date browser!</p>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-6">
+    <div id="olmap"></div>
+  </div>
+  <div class="col-md-6">
+    <textarea id="sld"></textarea>
+  </div>
+</div>
+</div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.41.0/codemirror.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.41.0/mode/xml/xml.min.js"></script>
+<script src="assets/benelux.js"></script>
+</body>
+
+</html>

--- a/docs/grenzen.html
+++ b/docs/grenzen.html
@@ -6,6 +6,7 @@ title: Gelderland
   <div class="col-md-12">
     <h2 class="pt-3">Openlayers nl districts</h2>
     <p>This example requires an up to date browser!</p>
+    <p><a href="assets/grenzen.js">View code</a></p>
   </div>
 </div>
 <div class="row">

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -554,6 +554,7 @@ export function createOlStyleFunction(featureTypeStyle, options = {}) {
         loadExternalGraphic(
           imageUrl,
           imageCache,
+          imageLoadState,
           featureTypeStyle,
           imageLoadedCallback
         );

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -22,18 +22,39 @@ const imageCache = {};
 
 const defaultPointStyle = new Style({
   image: new Circle({
-    radius: 2,
+    radius: 8,
     fill: new Fill({
       color: 'blue',
+      fillOpacity: 0.7,
     }),
   }),
 });
 
-const redPointStyle = new Style({
+const imageLoadingStyle = new Style({
   image: new Circle({
-    radius: 2,
+    radius: 5,
+    fill: new Fill({
+      color: '#DDDDDD',
+    }),
+    stroke: new Stroke({
+      width: 1,
+      color: '#888888',
+    }),
+  }),
+});
+
+const imageErrorStyle = new Style({
+  image: new RegularShape({
+    angle: Math.PI / 4,
     fill: new Fill({
       color: 'red',
+    }),
+    points: 4,
+    radius1: 8,
+    radius2: 0,
+    stroke: new Stroke({
+      color: 'red',
+      width: 4,
     }),
   }),
 });
@@ -110,24 +131,6 @@ function lineStyle(linesymbolizer) {
 }
 
 /**
- * Create an OL style depicting a point where the externalgraphic is still loading.
- * @returns {OLStyle} An OL style instance.
- */
-function createImageLoadingStyle() {
-  // todo: figure out a style to signify a loading image.
-  return defaultPointStyle;
-}
-
-/**
- * Create an OL style depicting a point where the externalgraphic has failed to load.
- * @returns {OLStyle} An OL style instance.
- */
-function createImageErrorStyle() {
-  // todo: figure out a better style to signify a failed load of an external graphic.
-  return redPointStyle;
-}
-
-/**
  * Create an OL Icon style for an external graphic.
  * The Graphic must be already loaded and present in the global imageCache.
  * @param {string} imageUrl Url of the external graphic.
@@ -162,12 +165,12 @@ function pointStyle(pointsymbolizer) {
           style.size
         );
       case IMAGE_LOADING:
-        return createImageLoadingStyle();
+        return imageLoadingStyle;
       case IMAGE_ERROR:
-        return createImageErrorStyle();
+        return imageErrorStyle;
       default:
         // A symbolizer should have loading state metadata, but return IMAGE_LOADING just in case.
-        return createImageLoadingStyle();
+        return imageLoadingStyle;
     }
   }
   if (style.mark) {

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -488,15 +488,21 @@ function getOlFeatureProperty(feature, propertyName) {
 
 /**
  * Create an OpenLayers style function from a FeatureTypeStyle object extracted from an SLD document.
+ *
+ * **Important!** When using externalGraphics for point styling, make sure to call .changed() on the layer
+ * inside options.imageLoadedCallback to immediately see the loaded image. If you do not do this, the
+ * image icon will only become visible the next time OpenLayers draws the layer (after pan or zoom).
  * @param {FeatureTypeStyle} featureTypeStyle Feature Type Style object.
  * @param {object} options Options
  * @param {function} options.convertResolution An optional function to convert the resolution in map units/pixel to resolution in meters/pixel.
  * When not given, the map resolution is used as-is.
- * @param {function} options.imageLoadedCallback Optional callback that will be called each time the image from a pointsymbolizer using
- * an ExernalGraphic has loaded. Refresh the layer by calling .Todo: uitzoeken.Error.Error.
+ * @param {function} options.imageLoadedCallback Optional callback that will be called with the url of an externalGraphic when
+ * an image has been loaded (successfully or not). Call .changed() inside the callback on the layer to see the loaded image.
  * @returns {Function} A function that can be set as style function on an OpenLayers vector style layer.
  * @example
- * myOlVectorLayer.setStyle(SLDReader.createOlStyleFunction(featureTypeStyle));
+ * myOlVectorLayer.setStyle(SLDReader.createOlStyleFunction(featureTypeStyle, {
+ *   imageLoadedCallback: () => { myOlVectorLayer.changed(); }
+ * }));
  */
 export function createOlStyleFunction(featureTypeStyle, options = {}) {
   const imageLoadedCallback = options.imageLoadedCallback || (() => {});

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -492,6 +492,8 @@ function getOlFeatureProperty(feature, propertyName) {
  * @param {object} options Options
  * @param {function} options.convertResolution An optional function to convert the resolution in map units/pixel to resolution in meters/pixel.
  * When not given, the map resolution is used as-is.
+ * @param {function} options.imageLoadedCallback Optional callback that will be called each time the image from a pointsymbolizer using
+ * an ExernalGraphic has loaded. Refresh the layer by calling .Todo: uitzoeken.Error.Error.
  * @returns {Function} A function that can be set as style function on an OpenLayers vector style layer.
  * @example
  * myOlVectorLayer.setStyle(SLDReader.createOlStyleFunction(featureTypeStyle));

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -118,6 +118,7 @@ function updateExternalGraphicRules(
 export function loadExternalGraphic(
   imageUrl,
   imageCache,
+  imageLoadState,
   featureTypeStyle,
   imageLoadedCallback
 ) {
@@ -131,6 +132,7 @@ export function loadExternalGraphic(
       height: image.naturalHeight,
     };
     updateExternalGraphicRules(featureTypeStyle, imageUrl, IMAGE_LOADED);
+    imageLoadState[imageUrl] = IMAGE_LOADED;
     if (typeof imageLoadedCallback === 'function') {
       imageLoadedCallback(imageUrl);
     }
@@ -138,6 +140,7 @@ export function loadExternalGraphic(
 
   image.onerror = () => {
     updateExternalGraphicRules(featureTypeStyle, imageUrl, IMAGE_ERROR);
+    imageLoadState[imageUrl] = IMAGE_ERROR;
     if (typeof imageLoadedCallback === 'function') {
       imageLoadedCallback();
     }

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-underscore-dangle */
+import { IMAGE_LOADED, IMAGE_ERROR } from './constants';
 import { scaleSelector, filterSelector } from './Filter';
 /**
  * get all layer names in sld
@@ -73,4 +75,73 @@ export function getRules(featureTypeStyle, feature, resolution, options = {}) {
     }
   }
   return result;
+}
+
+/**
+ * Go through all rules with an external graphic matching the image url
+ * and update the __loadingState metadata for the symbolizers with the new imageLoadState.
+ * This action replacec symbolizers with new symbolizers if they get a new __loadingState.
+ * @param {object} featureTypeStyle A feature type style object.
+ * @param {string} imageUrl The image url.
+ * @param {string} imageLoadState One of 'IMAGE_LOADING', 'IMAGE_LOADED', 'IMAGE_ERROR'.
+ */
+function updateExternalGraphicRules(
+  featureTypeStyle,
+  imageUrl,
+  imageLoadState
+) {
+  // Go through all rules with an external graphic matching the image url
+  // and update the __loadingState metadata for the symbolizers with the new imageLoadState.
+  if (!featureTypeStyle.rules) {
+    return;
+  }
+
+  featureTypeStyle.rules.forEach(rule => {
+    if (!(rule.pointsymbolizer && rule.pointsymbolizer.graphic)) {
+      return;
+    }
+
+    const { graphic } = rule.pointsymbolizer;
+    const { externalgraphic } = graphic;
+    if (
+      externalgraphic &&
+      externalgraphic.onlineresource === imageUrl &&
+      rule.pointsymbolizer.__loadingState !== imageLoadState
+    ) {
+      rule.pointsymbolizer = Object.assign({}, rule.pointsymbolizer, {
+        __loadingState: imageLoadState,
+      });
+    }
+  });
+}
+
+export function loadExternalGraphic(
+  imageUrl,
+  imageCache,
+  featureTypeStyle,
+  imageLoadedCallback
+) {
+  const image = new Image();
+
+  image.onload = () => {
+    imageCache[imageUrl] = {
+      imageUrl,
+      image,
+      width: image.naturalWidth,
+      height: image.naturalHeight,
+    };
+    updateExternalGraphicRules(featureTypeStyle, imageUrl, IMAGE_LOADED);
+    if (typeof imageLoadedCallback === 'function') {
+      imageLoadedCallback();
+    }
+  };
+
+  image.onerror = () => {
+    updateExternalGraphicRules(featureTypeStyle, imageUrl, IMAGE_ERROR);
+    if (typeof imageLoadedCallback === 'function') {
+      imageLoadedCallback();
+    }
+  };
+
+  image.src = imageUrl;
 }

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -125,7 +125,7 @@ export function loadExternalGraphic(
 
   image.onload = () => {
     imageCache[imageUrl] = {
-      imageUrl,
+      url: imageUrl,
       image,
       width: image.naturalWidth,
       height: image.naturalHeight,

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -132,7 +132,7 @@ export function loadExternalGraphic(
     };
     updateExternalGraphicRules(featureTypeStyle, imageUrl, IMAGE_LOADED);
     if (typeof imageLoadedCallback === 'function') {
-      imageLoadedCallback();
+      imageLoadedCallback(imageUrl);
     }
   };
 

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -80,7 +80,7 @@ export function getRules(featureTypeStyle, feature, resolution, options = {}) {
 /**
  * Go through all rules with an external graphic matching the image url
  * and update the __loadingState metadata for the symbolizers with the new imageLoadState.
- * This action replacec symbolizers with new symbolizers if they get a new __loadingState.
+ * This action replaces symbolizers with new symbolizers if they get a new __loadingState.
  * @param {object} featureTypeStyle A feature type style object.
  * @param {string} imageUrl The image url.
  * @param {string} imageLoadState One of 'IMAGE_LOADING', 'IMAGE_LOADED', 'IMAGE_ERROR'.

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,3 @@
+export const IMAGE_LOADING = 'IMAGE_LOADING';
+export const IMAGE_LOADED = 'IMAGE_LOADED';
+export const IMAGE_ERROR = 'IMAGE_ERROR';

--- a/test/data/externalgraphic.sld.js
+++ b/test/data/externalgraphic.sld.js
@@ -1,0 +1,92 @@
+export const externalGraphicSld = `<?xml version="1.0" encoding="UTF-8"?>
+<sld:StyledLayerDescriptor xmlns="http://www.opengis.net/sld" 
+  xmlns:sld="http://www.opengis.net/sld" 
+  xmlns:ogc="http://www.opengis.net/ogc" 
+  xmlns:gml="http://www.opengis.net/gml" 
+  xmlns:xlink="http://www.w3.org/1999/xlink" version="1.0.0">
+  <NamedLayer>
+    <sld:Name>icons_puntenlaag</sld:Name>
+    <UserStyle>
+      <sld:Name>icons_puntenlaag</sld:Name>
+      <sld:FeatureTypeStyle>
+        <sld:Rule>
+          <sld:Name>Type 1</sld:Name>
+          <sld:Description>
+            <sld:Title>Type 1</sld:Title>
+          </sld:Description>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:PropertyIsEqualTo>
+              <ogc:PropertyName>type</ogc:PropertyName>
+              <ogc:Literal>1</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <sld:PointSymbolizer>
+            <sld:Graphic>
+              <sld:ExternalGraphic>
+                <sld:OnlineResource xlink:type="simple" xlink:href="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="/>
+                <sld:Format>image/png</sld:Format>
+              </sld:ExternalGraphic>
+              <sld:Size>24</sld:Size>
+            </sld:Graphic>>
+          </sld:PointSymbolizer>
+        </sld:Rule>
+        <sld:Rule>
+          <sld:Name>Type 2</sld:Name>
+          <sld:Description>
+            <sld:Title>Type 2</sld:Title>
+          </sld:Description>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:PropertyIsEqualTo>
+              <ogc:PropertyName>type</ogc:PropertyName>
+              <ogc:Literal>2</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <sld:PointSymbolizer>
+            <sld:Graphic>
+              <sld:ExternalGraphic>
+                <sld:OnlineResource xlink:type="simple" xlink:href="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"/>
+                <sld:Format>image/png</sld:Format>
+              </sld:ExternalGraphic>
+              <sld:Size>24</sld:Size>
+            </sld:Graphic>
+          </sld:PointSymbolizer>
+        </sld:Rule>
+        <sld:Rule>
+          <sld:Name>Type 3</sld:Name>
+          <sld:Description>
+            <sld:Title>Type 3</sld:Title>
+          </sld:Description>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:PropertyIsEqualTo>
+              <ogc:PropertyName>type</ogc:PropertyName>
+              <ogc:Literal>3</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <sld:PointSymbolizer>
+            <sld:Graphic>
+              <sld:ExternalGraphic>
+                <sld:OnlineResource xlink:type="simple" xlink:href="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="/>
+                <sld:Format>image/png</sld:Format>
+              </sld:ExternalGraphic>
+              <sld:Size>24</sld:Size>
+            </sld:Graphic>
+          </sld:PointSymbolizer>
+        </sld:Rule>
+        <sld:Rule>
+          <ogc:ElseFilter />
+          <sld:PointSymbolizer>
+            <sld:Graphic>
+              <sld:ExternalGraphic>
+                <sld:OnlineResource xlink:type="simple" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQYV2NgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII="/>
+                <sld:Format>image/png</sld:Format>
+              </sld:ExternalGraphic>
+              <sld:Size>24</sld:Size>
+            </sld:Graphic>
+          </sld:PointSymbolizer>
+        </sld:Rule>
+      </sld:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</sld:StyledLayerDescriptor>`;
+
+export default externalGraphicSld;


### PR DESCRIPTION
In this pull request, external graphic icons are put into an image cache after load, so the correct scale can be calculated from the width and height of the loaded image.

With this, the parameter Size works as expected within a PointSymbolizer that uses an ExternalGraphic.