### PR TITLE
Fix sld graphic scaling

### DIFF
--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -986,13 +986,12 @@
     var image = ref.image;
     var width = ref.width;
     var height = ref.height;
-    var maxSide = Math.max(width, height);
     return new style.Style({
       image: new style.Icon({
         img: image,
         imgSize: [width, height],
-        // Calculate scale so the image will be resized to the requested size.
-        scale: size / maxSide || 1,
+        // According to SLD spec, if size is given, image height should equal the given size.
+        scale: size / height || 1,
       }),
     });
   }
@@ -1040,7 +1039,7 @@
       } else {
         stroke = undefined;
       }
-      var radius = Number(style$1.size) || 10;
+      var radius = (0.5 * Number(style$1.size)) || 10;
       switch (style$1.mark.wellknownname) {
         case 'circle':
           return new style.Style({

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -1106,7 +1106,8 @@
               angle: Math.PI / 4,
               fill: fill,
               points: 4,
-              radius: radius,
+              // For square, scale radius so the height of the square equals the given size.
+              radius: radius * Math.sqrt(2.0),
               stroke: stroke,
             }),
           });

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -248,7 +248,8 @@ function pointStyle(pointsymbolizer) {
             angle: Math.PI / 4,
             fill,
             points: 4,
-            radius,
+            // For square, scale radius so the height of the square equals the given size.
+            radius: radius * Math.sqrt(2.0),
             stroke,
           }),
         });

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -132,13 +132,12 @@ function lineStyle(linesymbolizer) {
  */
 function createCachedImageStyle(imageUrl, size) {
   const { image, width, height } = imageCache[imageUrl];
-  const maxSide = Math.max(width, height);
   return new Style({
     image: new Icon({
       img: image,
       imgSize: [width, height],
-      // Calculate scale so the image will be resized to the requested size.
-      scale: size / maxSide || 1,
+      // According to SLD spec, if size is given, image height should equal the given size.
+      scale: size / height || 1,
     }),
   });
 }
@@ -182,7 +181,7 @@ function pointStyle(pointsymbolizer) {
     } else {
       stroke = undefined;
     }
-    const radius = Number(style.size) || 10;
+    const radius = (0.5 * Number(style.size)) || 10;
     switch (style.mark.wellknownname) {
       case 'circle':
         return new Style({


### PR DESCRIPTION
This pull request fixes a few issues with how the Size parameter is applied inside a Graphic element.
* When using a Mark, the Size parameter now correctly sets the diameter (or height in case of a square).
* When using an ExternalGraphic, the image is scaled so the height equals the given Size.