### PR TITLE
Fix typo in test `creates point style`

### DIFF
--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -172,7 +172,7 @@ function pointStyle(pointsymbolizer) {
     fill = new Fill({
       color: fillColor,
     });
-    if (stroke && !(Number(stroke.styling.strokeWidth) === 0)) {
+    if (stroke && stroke.styling && !(Number(stroke.styling.strokeWidth) === 0)) {
       const { stroke: cssStroke, strokeWidth: cssStrokeWidth } = stroke.styling;
       stroke = new Stroke({
         color: cssStroke || 'black',

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -74,7 +74,7 @@ describe('creates point style', () => {
           mark: {
             wellknownname: 'circle',
             fill: {},
-            strok: {},
+            stroke: {},
           },
           opactity: 20,
           size: 10,


### PR DESCRIPTION
There was a typo in test causing it's passing, while it shouldn't pass. Also fixed code to make this fixed test passing.