### PR TITLE
Support external graphic as fill for polygons

### DIFF
--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -79,17 +79,16 @@ function createPattern(graphic) {
   }
   const cnv = document.createElement('canvas');
   const ctx = cnv.getContext('2d');
-  if (imageRatio == 1) {
+  if (imageRatio === 1) {
     return ctx.createPattern(image, 'repeat');
-  } else {
-    const tempCanvas = document.createElement("canvas");
-    const tCtx = tempCanvas.getContext("2d");
-
-    tempCanvas.width = width * imageRatio;
-    tempCanvas.height = height * imageRatio;
-    tCtx.drawImage(image, 0, 0, width, height, 0, 0, width * imageRatio, height * imageRatio);
-    return ctx.createPattern(tempCanvas, 'repeat');
   }
+  const tempCanvas = document.createElement('canvas');
+  const tCtx = tempCanvas.getContext('2d');
+
+  tempCanvas.width = width * imageRatio;
+  tempCanvas.height = height * imageRatio;
+  tCtx.drawImage(image, 0, 0, width, height, 0, 0, width * imageRatio, height * imageRatio);
+  return ctx.createPattern(tempCanvas, 'repeat');
 }
 
 function polygonStyle(style) {
@@ -101,12 +100,12 @@ function polygonStyle(style) {
     // Check symbolizer metadata to see if the image has already been loaded.
     switch (style.__loadingState) {
       case IMAGE_LOADED:
+        const pattern = createPattern(style.fill.graphicfill.graphic);
         return(new Style({
           fill: new Fill({
-            color: createPattern(style.fill.graphicfill.graphic)
-          })
-          }));
-
+            color: pattern,
+          }),
+        }));
       case IMAGE_LOADING:
         return imageLoadingStyle;
       case IMAGE_ERROR:

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -119,7 +119,7 @@ function polygonStyle(style) {
     // Check symbolizer metadata to see if the image has already been loaded.
     switch (style.__loadingState) {
       case IMAGE_LOADED:
-        return(new Style({
+        return (new Style({
           fill: new Fill({
             color: createPattern(style.fill.graphicfill.graphic),
           }),

--- a/src/Reader.js
+++ b/src/Reader.js
@@ -146,6 +146,7 @@ const SymbParsers = {
   TextSymbolizer: addProp,
   Fill: addProp,
   Stroke: addProp,
+  GraphicFill: addProp,
   Graphic: addProp,
   ExternalGraphic: addProp,
   Mark: addProp,

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import { IMAGE_LOADED, IMAGE_ERROR } from './constants';
+import { IMAGE_LOADED, IMAGE_ERROR, IMAGE_LOADING } from './constants';
 import { scaleSelector, filterSelector } from './Filter';
 /**
  * get all layer names in sld
@@ -97,23 +97,56 @@ function updateExternalGraphicRules(
   }
 
   featureTypeStyle.rules.forEach(rule => {
-    if (!(rule.pointsymbolizer && rule.pointsymbolizer.graphic)) {
-      return;
-    }
-
-    const { graphic } = rule.pointsymbolizer;
-    const { externalgraphic } = graphic;
-    if (
-      externalgraphic &&
-      externalgraphic.onlineresource === imageUrl &&
-      rule.pointsymbolizer.__loadingState !== imageLoadState
-    ) {
-      rule.pointsymbolizer = Object.assign({}, rule.pointsymbolizer, {
-        __loadingState: imageLoadState,
-      });
-    }
+    updateExternalGraphicRule(rule, imageUrl, imageLoadState)
   });
 }
+
+/**
+ * Updates the __loadingState metadata for the symbolizers with the new imageLoadState, if
+ * the external graphic is matching the image url.
+ * This action replaces symbolizers with new symbolizers if they get a new __loadingState.
+ * @param {object} featureTypeStyle A feature type style object.
+ * @param {string} imageUrl The image url.
+ * @param {string} imageLoadState One of 'IMAGE_LOADING', 'IMAGE_LOADED', 'IMAGE_ERROR'.
+ */
+export function updateExternalGraphicRule(
+  rule,
+  imageUrl,
+  imageLoadState
+) {
+    // for pointsymbolizer
+    if (rule.pointsymbolizer && rule.pointsymbolizer.graphic) {
+        const { graphic } = rule.pointsymbolizer;
+        const { externalgraphic } = graphic;
+        if (
+          externalgraphic &&
+          externalgraphic.onlineresource === imageUrl &&
+          rule.pointsymbolizer.__loadingState !== imageLoadState
+        ) {
+          rule.pointsymbolizer = Object.assign({}, rule.pointsymbolizer, {
+            __loadingState: imageLoadState,
+          });
+        }
+    }
+    // for polygonsymbolizer
+    if (rule.polygonsymbolizer
+            && rule.polygonsymbolizer.fill
+            && rule.polygonsymbolizer.fill.graphicfill
+            && rule.polygonsymbolizer.fill.graphicfill.graphic) {
+        const { graphic } = rule.polygonsymbolizer.fill.graphicfill;
+        const { externalgraphic } = graphic;
+        if (
+          externalgraphic &&
+          externalgraphic.onlineresource === imageUrl &&
+          rule.polygonsymbolizer.__loadingState !== imageLoadState
+        ) {
+          rule.polygonsymbolizer = Object.assign({}, rule.polygonsymbolizer, {
+            __loadingState: imageLoadState,
+          });
+        }
+    }
+}
+
 
 export function loadExternalGraphic(
   imageUrl,
@@ -147,4 +180,5 @@ export function loadExternalGraphic(
   };
 
   image.src = imageUrl;
+  updateExternalGraphicRules(featureTypeStyle, imageUrl, IMAGE_LOADING);
 }

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -97,7 +97,7 @@ function updateExternalGraphicRules(
   }
 
   featureTypeStyle.rules.forEach(rule => {
-    updateExternalGraphicRule(rule, imageUrl, imageLoadState)
+    updateExternalGraphicRule(rule, imageUrl, imageLoadState);
   });
 }
 
@@ -114,37 +114,37 @@ export function updateExternalGraphicRule(
   imageUrl,
   imageLoadState
 ) {
-    // for pointsymbolizer
-    if (rule.pointsymbolizer && rule.pointsymbolizer.graphic) {
-        const { graphic } = rule.pointsymbolizer;
-        const { externalgraphic } = graphic;
-        if (
-          externalgraphic &&
-          externalgraphic.onlineresource === imageUrl &&
-          rule.pointsymbolizer.__loadingState !== imageLoadState
-        ) {
-          rule.pointsymbolizer = Object.assign({}, rule.pointsymbolizer, {
-            __loadingState: imageLoadState,
-          });
-        }
+  // for pointsymbolizer
+  if (rule.pointsymbolizer && rule.pointsymbolizer.graphic) {
+    const { graphic } = rule.pointsymbolizer;
+    const { externalgraphic } = graphic;
+    if (
+      externalgraphic &&
+      externalgraphic.onlineresource === imageUrl &&
+      rule.pointsymbolizer.__loadingState !== imageLoadState
+    ) {
+      rule.pointsymbolizer = Object.assign({}, rule.pointsymbolizer, {
+        __loadingState: imageLoadState,
+      });
     }
-    // for polygonsymbolizer
-    if (rule.polygonsymbolizer
-            && rule.polygonsymbolizer.fill
-            && rule.polygonsymbolizer.fill.graphicfill
-            && rule.polygonsymbolizer.fill.graphicfill.graphic) {
-        const { graphic } = rule.polygonsymbolizer.fill.graphicfill;
-        const { externalgraphic } = graphic;
-        if (
-          externalgraphic &&
-          externalgraphic.onlineresource === imageUrl &&
-          rule.polygonsymbolizer.__loadingState !== imageLoadState
-        ) {
-          rule.polygonsymbolizer = Object.assign({}, rule.polygonsymbolizer, {
-            __loadingState: imageLoadState,
-          });
-        }
+  }
+  // for polygonsymbolizer
+  if (rule.polygonsymbolizer
+        && rule.polygonsymbolizer.fill
+        && rule.polygonsymbolizer.fill.graphicfill
+        && rule.polygonsymbolizer.fill.graphicfill.graphic) {
+    const { graphic } = rule.polygonsymbolizer.fill.graphicfill;
+    const { externalgraphic } = graphic;
+    if (
+      externalgraphic &&
+      externalgraphic.onlineresource === imageUrl &&
+      rule.polygonsymbolizer.__loadingState !== imageLoadState
+    ) {
+      rule.polygonsymbolizer = Object.assign({}, rule.polygonsymbolizer, {
+        __loadingState: imageLoadState,
+      });
     }
+  }
 }
 
 


### PR DESCRIPTION
Hi,
i made it possible to use external graphics as pattern background for polygons. 

Example sld:
`
<sld:PolygonSymbolizer>
                        <sld:Fill>
                            <sld:GraphicFill>
                                <sld:Graphic>
                                    <sld:ExternalGraphic>
                                        <sld:OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAj0lEQVR4Xu2RsQ3AQAwCPzNlp+y/wSefkoIWg7CEi5MoTqzn3ts567zvLowLr4CaV0DNfwHnZCyAkBWm8QqoeYaAczIWQMgK03gF1DxDwDkZCyBkhWm8AmqeIeCcjAUQssI0XgE1zxBwTsYCCFlhGq+AmmcIOCdjAYSsMI1XQM0zBJyTsQBCVpjGK6Dm9gIvxmrUOF2e6O8AAAAASUVORK5C"></sld:OnlineResource>
                                        <sld:Format>image/png</sld:Format>
                                    </sld:ExternalGraphic>
                                    <sld:Opacity>1.0</sld:Opacity>
                                    <sld:Size>48.0</sld:Size>
                                    <sld:Rotation>0.0</sld:Rotation>
                                </sld:Graphic>
                            </sld:GraphicFill>
                            <sld:CssParameter name="fill">#808080</sld:CssParameter>
                            <sld:CssParameter name="fill-opacity">1.0</sld:CssParameter>
                        </sld:Fill>
                    </sld:PolygonSymbolizer>
`

rendered result :
![image](https://user-images.githubusercontent.com/14180834/66517541-97658780-eae3-11e9-8a10-54d232513b85.png)
