### PR TITLE
Multiple shapes

### DIFF
--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -289,6 +289,20 @@ function pointStyle(pointsymbolizer) {
               }),
           }),
         });
+      case 'hexagon':
+        return new Style({
+          image: new RegularShape({
+            fill,
+            points: 8,
+            radius1: radius,
+            stroke:
+              stroke ||
+              new Stroke({
+                color: fillColor,
+                width: radius / 2,
+              }),
+          }),
+        });
       case 'x':
         return new Style({
           image: new RegularShape({

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -293,7 +293,7 @@ function pointStyle(pointsymbolizer) {
         return new Style({
           image: new RegularShape({
             fill,
-            points: 8,
+            points: 6,
             radius1: radius,
             stroke:
               stroke ||

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -505,6 +505,24 @@ const cachedPolygonStyle = memoize(polygonStyle);
 
 const defaultStyles = [defaultPointStyle];
 
+
+/**
+ * Pushes style to array
+ * @example pushTo(styles, point[j], cachedPointStyle);
+ * @param {array} styles rulesconverter
+ * @param {object} item style description of array of styles description
+ * @param {function} cache function that returns cached style
+ */
+function pushTo(array, item, cache) {
+  if (Array.isArray(item)) {
+    for(let k = 0; k < item.length; k += 1) {
+      array.push(cache(item[k]));
+    }
+  } else {
+    array.push(cache(item));
+  }
+}
+
 /**
  * Create openlayers style
  * @example OlStyler(getGeometryStyles(rules), geojson.geometry.type);
@@ -524,7 +542,7 @@ export default function OlStyler(GeometryStyles, feature) {
     case 'Polygon':
     case 'MultiPolygon':
       for (let i = 0; i < polygon.length; i += 1) {
-        styles.push(cachedPolygonStyle(polygon[i]));
+        pushTo(styles, polygon[i], cachedPolygonStyle)
       }
       for (let j = 0; j < text.length; j += 1) {
         styles.push(textStyle(text[j], feature, 'polygon'));
@@ -533,7 +551,7 @@ export default function OlStyler(GeometryStyles, feature) {
     case 'LineString':
     case 'MultiLineString':
       for (let j = 0; j < line.length; j += 1) {
-        styles.push(cachedLineStyle(line[j]));
+        pushTo(styles, line[j], cachedLineStyle)
       }
       for (let j = 0; j < text.length; j += 1) {
         styles.push(textStyle(text[j], feature, 'line'));
@@ -542,7 +560,7 @@ export default function OlStyler(GeometryStyles, feature) {
     case 'Point':
     case 'MultiPoint':
       for (let j = 0; j < point.length; j += 1) {
-        styles.push(cachedPointStyle(point[j]));
+        pushTo(styles, point[j], cachedPointStyle)
       }
       for (let j = 0; j < text.length; j += 1) {
         styles.push(textStyle(text[j], feature, 'point'));

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -515,7 +515,7 @@ const defaultStyles = [defaultPointStyle];
  */
 function pushTo(array, item, cache) {
   if (Array.isArray(item)) {
-    for(let k = 0; k < item.length; k += 1) {
+    for (let k = 0; k < item.length; k += 1) {
       array.push(cache(item[k]));
     }
   } else {
@@ -542,7 +542,7 @@ export default function OlStyler(GeometryStyles, feature) {
     case 'Polygon':
     case 'MultiPolygon':
       for (let i = 0; i < polygon.length; i += 1) {
-        pushTo(styles, polygon[i], cachedPolygonStyle)
+        pushTo(styles, polygon[i], cachedPolygonStyle);
       }
       for (let j = 0; j < text.length; j += 1) {
         styles.push(textStyle(text[j], feature, 'polygon'));
@@ -551,7 +551,7 @@ export default function OlStyler(GeometryStyles, feature) {
     case 'LineString':
     case 'MultiLineString':
       for (let j = 0; j < line.length; j += 1) {
-        pushTo(styles, line[j], cachedLineStyle)
+        pushTo(styles, line[j], cachedLineStyle);
       }
       for (let j = 0; j < text.length; j += 1) {
         styles.push(textStyle(text[j], feature, 'line'));
@@ -560,7 +560,7 @@ export default function OlStyler(GeometryStyles, feature) {
     case 'Point':
     case 'MultiPoint':
       for (let j = 0; j < point.length; j += 1) {
-        pushTo(styles, point[j], cachedPointStyle)
+        pushTo(styles, point[j], cachedPointStyle);
       }
       for (let j = 0; j < text.length; j += 1) {
         styles.push(textStyle(text[j], feature, 'point'));

--- a/src/Reader.js
+++ b/src/Reader.js
@@ -30,7 +30,7 @@ function addPropOrArray(node, obj, prop) {
   } else if (Array.isArray(obj[property])) {
     obj[property].push(item)
   } else {
-    obj[property] = [obj[property]]
+    obj[property] = [obj[property], item]
   }
 }
 

--- a/src/Reader.js
+++ b/src/Reader.js
@@ -26,11 +26,11 @@ function addPropOrArray(node, obj, prop) {
   const item = {};
   readNode(node, item);
   if (!(property in obj)) {
-    obj[property] = item
+    obj[property] = item;
   } else if (Array.isArray(obj[property])) {
-    obj[property].push(item)
+    obj[property].push(item);
   } else {
-    obj[property] = [obj[property], item]
+    obj[property] = [obj[property], item];
   }
 }
 

--- a/src/Reader.js
+++ b/src/Reader.js
@@ -15,6 +15,26 @@ function addPropArray(node, obj, prop) {
 }
 
 /**
+ * Generic parser for elements that can be arrays
+ * @private
+ * @param {Element} node the xml element to parse
+ * @param {object|Array} obj  the object or array to modify
+ * @param {string} prop key on obj to hold array
+ */
+function addPropOrArray(node, obj, prop) {
+  const property = prop.toLowerCase();
+  const item = {};
+  readNode(node, item);
+  if (!(property in obj)) {
+    obj[property] = item
+  } else if (Array.isArray(obj[property])) {
+    obj[property].push(item)
+  } else {
+    obj[property] = [obj[property]]
+  }
+}
+
+/**
  * Generic parser for maxOccurs = 1 (the xsd default)
  * it sets result of readNode(node) to array on obj[prop]
  * @private
@@ -140,10 +160,10 @@ const FilterParsers = {
 };
 
 const SymbParsers = {
-  PolygonSymbolizer: addProp,
-  LineSymbolizer: addProp,
-  PointSymbolizer: addProp,
-  TextSymbolizer: addProp,
+  PolygonSymbolizer: addPropOrArray,
+  LineSymbolizer: addPropOrArray,
+  PointSymbolizer: addPropOrArray,
+  TextSymbolizer: addPropOrArray,
   Fill: addProp,
   Stroke: addProp,
   GraphicFill: addProp,

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -6,6 +6,7 @@ import OLFormatGeoJSON from 'ol/format/GeoJSON';
 import Reader from '../src/Reader';
 import OlStyler, { createOlStyleFunction } from '../src/OlStyler';
 
+import { sld } from './data/test.sld';
 import { sld11 } from './data/test11.sld';
 import { externalGraphicSld } from './data/externalgraphic.sld';
 import { IMAGE_LOADING, IMAGE_LOADED } from '../src/constants';
@@ -122,6 +123,34 @@ describe('Create OL Style function from SLD feature type style', () => {
 
     expect(featureStyle.getStroke().getColor()).to.equal('#000000');
     expect(featureStyle.getStroke().getWidth()).to.equal('4');
+  });
+});
+
+
+describe('Create OL Style function from SLD feature type style 1', () => {
+  let sldObject;
+  let featureTypeStyle;
+  before(() => {
+    sldObject = Reader(sld);
+    [featureTypeStyle] = sldObject.layers[4].styles[0].featuretypestyles;
+  });
+
+  const geojson = {
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [0, 0],
+    },
+  };
+
+  it('Style function applied to OpenLayers feature', () => {
+    const fmtGeoJSON = new OLFormatGeoJSON();
+    const olFeature = fmtGeoJSON.readFeature(geojson);
+
+    const styleFunction = createOlStyleFunction(featureTypeStyle);
+
+    const featureStyle = styleFunction(olFeature, null);
+    console.log(JSON.stringify(featureStyle, null, 2))
   });
 });
 

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -143,14 +143,17 @@ describe('Create OL Style function from SLD feature type style 1', () => {
     },
   };
 
-  it('Style function applied to OpenLayers feature', () => {
+  it.only('Multiple styles with the same shape on one feature', () => {
     const fmtGeoJSON = new OLFormatGeoJSON();
     const olFeature = fmtGeoJSON.readFeature(geojson);
 
     const styleFunction = createOlStyleFunction(featureTypeStyle);
 
     const featureStyle = styleFunction(olFeature, null);
-    console.log(JSON.stringify(featureStyle, null, 2))
+    expect(featureStyle).to.be.an('array');
+    expect(featureStyle.length).to.be.equal(2);
+    expect(() => featureStyle[0].getImage().getRadius()).to.not.throw().and.be.equal(7);
+    expect(() => featureStyle[1].getImage().getRadius()).to.not.throw().and.be.equal(2);
   });
 });
 

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -143,7 +143,7 @@ describe('Create OL Style function from SLD feature type style 1', () => {
     },
   };
 
-  it.only('Multiple styles with the same shape on one feature', () => {
+  it('Multiple styles with the same shape on one feature', () => {
     const fmtGeoJSON = new OLFormatGeoJSON();
     const olFeature = fmtGeoJSON.readFeature(geojson);
 

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -62,7 +62,7 @@ describe('Reads xml', () => {
     expect(rule.pointsymbolizer.graphic.mark).to.have.property('wellknownname');
     expect(rule.pointsymbolizer.graphic.mark.wellknownname).to.equal('cross');
   });
-  it.only('reads multiple pointsymbolizers', () => {
+  it('reads multiple pointsymbolizers', () => {
     const rule = result.layers['4'].styles['0'].featuretypestyles['0'].rules['0'];
     expect(rule).to.have.property('pointsymbolizer');
     const pointSymbolizers = rule.pointsymbolizer

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -65,7 +65,7 @@ describe('Reads xml', () => {
   it('reads multiple pointsymbolizers', () => {
     const rule = result.layers['4'].styles['0'].featuretypestyles['0'].rules['0'];
     expect(rule).to.have.property('pointsymbolizer');
-    const pointSymbolizers = rule.pointsymbolizer
+    const pointSymbolizers = rule.pointsymbolizer;
     expect(pointSymbolizers).to.be.an('array');
     expect(pointSymbolizers.length).to.equal(2);
     expect(pointSymbolizers[0]).to.have.property('graphic');

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -15,8 +15,8 @@ describe('Reads xml', () => {
     expect(result.layers).to.be.an.instanceof(Array);
   });
   it('returns object for the layers', () => {
-    const layernames = ['WaterBodies', 'Roads', 'Cities', 'Land'];
-    expect(result.layers).to.have.length(4);
+    const layernames = ['WaterBodies', 'Roads', 'Cities', 'Land', 'Hexagons'];
+    expect(result.layers).to.have.length(5);
     for (let i = 0; i < result.layers.length; i += 1) {
       expect(result.layers[i].name).to.equal(layernames[i]);
     }
@@ -61,6 +61,18 @@ describe('Reads xml', () => {
     expect(rule.pointsymbolizer.graphic).to.have.property('size');
     expect(rule.pointsymbolizer.graphic.mark).to.have.property('wellknownname');
     expect(rule.pointsymbolizer.graphic.mark.wellknownname).to.equal('cross');
+  });
+  it.only('reads multiple pointsymbolizers', () => {
+    const rule = result.layers['4'].styles['0'].featuretypestyles['0'].rules['0'];
+    expect(rule).to.have.property('pointsymbolizer');
+    const pointSymbolisers = rule.pointsymbolizer
+    console.log(pointSymbolisers)
+    expect(pointSymbolisers).to.be.an('array').that.includes(2)
+    expect(pointsymbolizers[0]).to.have.property('graphic');
+    expect(pointsymbolizers[0].graphic).to.have.property('mark');
+    expect(pointsymbolizers[0].graphic).to.have.property('size');
+    expect(pointsymbolizers[0].graphic.mark).to.have.property('wellknownname');
+    expect(pointsymbolizers[0].graphic.mark.wellknownname).to.equal('cross');
   });
 });
 

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -65,14 +65,14 @@ describe('Reads xml', () => {
   it.only('reads multiple pointsymbolizers', () => {
     const rule = result.layers['4'].styles['0'].featuretypestyles['0'].rules['0'];
     expect(rule).to.have.property('pointsymbolizer');
-    const pointSymbolisers = rule.pointsymbolizer
-    console.log(pointSymbolisers)
-    expect(pointSymbolisers).to.be.an('array').that.includes(2)
-    expect(pointsymbolizers[0]).to.have.property('graphic');
-    expect(pointsymbolizers[0].graphic).to.have.property('mark');
-    expect(pointsymbolizers[0].graphic).to.have.property('size');
-    expect(pointsymbolizers[0].graphic.mark).to.have.property('wellknownname');
-    expect(pointsymbolizers[0].graphic.mark.wellknownname).to.equal('cross');
+    const pointSymbolizers = rule.pointsymbolizer
+    expect(pointSymbolizers).to.be.an('array');
+    expect(pointSymbolizers.length).to.equal(2);
+    expect(pointSymbolizers[0]).to.have.property('graphic');
+    expect(pointSymbolizers[0].graphic).to.have.property('mark');
+    expect(pointSymbolizers[0].graphic).to.have.property('size');
+    expect(pointSymbolizers[0].graphic.mark).to.have.property('wellknownname');
+    expect(pointSymbolizers[0].graphic.mark.wellknownname).to.equal('hexagon');
   });
 });
 

--- a/test/data/test.sld.js
+++ b/test/data/test.sld.js
@@ -591,6 +591,47 @@ export const sld = `<?xml version="1.0" encoding="UTF-8"?>
     </sld:UserStyle>
   </sld:NamedLayer>
 
+  <sld:NamedLayer>
+    <sld:Name>Hexagons</sld:Name>
+    <sld:UserStyle>
+      <sld:Name>Hexagons Style</sld:Name>
+      <sld:FeatureTypeStyle>
+        <sld:Rule>
+          <sld:PointSymbolizer>
+            <sld:Graphic>
+              <sld:Mark>
+                <sld:WellKnownName>hexagon</sld:WellKnownName>
+                <sld:Fill>
+                  <sld:SvgParameter name="fill">#ffffff</sld:SvgParameter>
+                </sld:Fill>
+                <sld:Stroke>
+                  <sld:SvgParameter name="stroke">#fa8b39</sld:SvgParameter>
+                  <sld:SvgParameter name="stroke-width">2</sld:SvgParameter>
+                </sld:Stroke>
+              </sld:Mark>
+              <sld:Size>14</sld:Size>
+            </sld:Graphic>
+          </sld:PointSymbolizer>
+          <sld:PointSymbolizer>
+            <sld:Graphic>
+              <sld:Mark>
+                <sld:WellKnownName>hexagon</sld:WellKnownName>
+                <sld:Fill>
+                  <sld:SvgParameter name="fill">#fab07c</sld:SvgParameter>
+                </sld:Fill>
+                <sld:Stroke>
+                  <sld:SvgParameter name="stroke">#fab07c</sld:SvgParameter>
+                  <sld:SvgParameter name="stroke-width">1</sld:SvgParameter>
+                </sld:Stroke>
+              </sld:Mark>
+              <sld:Size>4</sld:Size>
+            </sld:Graphic>
+          </sld:PointSymbolizer>
+        </sld:Rule>
+      </sld:FeatureTypeStyle>
+    </sld:UserStyle>
+  </sld:NamedLayer>
+
 </sld:StyledLayerDescriptor>
 
 `;

--- a/test/data/test.sld.js
+++ b/test/data/test.sld.js
@@ -605,7 +605,7 @@ export const sld = `<?xml version="1.0" encoding="UTF-8"?>
                   <sld:SvgParameter name="fill">#ffffff</sld:SvgParameter>
                 </sld:Fill>
                 <sld:Stroke>
-                  <sld:SvgParameter name="stroke">#fa8b39</sld:SvgParameter>
+                  <sld:SvgParameter name="stroke">#ff0000</sld:SvgParameter>
                   <sld:SvgParameter name="stroke-width">2</sld:SvgParameter>
                 </sld:Stroke>
               </sld:Mark>
@@ -617,10 +617,10 @@ export const sld = `<?xml version="1.0" encoding="UTF-8"?>
               <sld:Mark>
                 <sld:WellKnownName>hexagon</sld:WellKnownName>
                 <sld:Fill>
-                  <sld:SvgParameter name="fill">#fab07c</sld:SvgParameter>
+                  <sld:SvgParameter name="fill">#ff0000</sld:SvgParameter>
                 </sld:Fill>
                 <sld:Stroke>
-                  <sld:SvgParameter name="stroke">#fab07c</sld:SvgParameter>
+                  <sld:SvgParameter name="stroke">#ff0000</sld:SvgParameter>
                   <sld:SvgParameter name="stroke-width">1</sld:SvgParameter>
                 </sld:Stroke>
               </sld:Mark>


### PR DESCRIPTION
Allows stacking shapes (like multiple PointSymbolizer in the same rule) allowing to do more complex symbols and shapes. Also adds `wellknown` `hexagon` and `octagon` (used in QGIS)