### PR TITLE
Fix label rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,13 @@ GraphicStroke, GraphicFill, and PerpendicularOffset are not supported.
 Polygons with static fill and stroke style parameters are supported. See LineSymbolizer above for supported stroke css-parameters. GraphicFill is also supported.
 
 #### TextSymbolizer
-Dynamic Labels (with PropertyName elements), Font and Halo are supported. No vendor-specific options are supported. LabelPlacement or PointPlacement are supported. Only static values for label rotation are supported. Graphic elements to display behind the label text are not supported.
-For PointPlacement, AnchorPoint is not supported.
-For LinePlacement, PerpendicularOffset is not supported.
+Dynamic Labels (with PropertyName elements), Font and Halo are supported. No vendor-specific options are supported. LabelPlacement or PointPlacement are supported. Graphic elements to display behind the label text are not supported.
+* For PointPlacement, Displacement is supported<sup>1</sup>.
+* For PointPlacement, Rotation is supported<sup>1</sup>. PropertyName as rotation value is supported.
+* For PointPlacement, AnchorPoint is not supported.
+* For LinePlacement, PerpendicularOffset is not supported.
+
+[1]: according to the SLD-spec, label rotation takes place before displacement, but OpenLayers applies displacement before rotation. Beware when combining rotation and displacement inside a single text symbolizer.
 
 ### Dynamic parameter values
 According to the SLD spec, most values can be mixed type (a combination ofplain text and [Filter expressions](https://docs.geoserver.org/stable/en/user/styling/sld/reference/filters.html#sld-filter-expression)). This means that most values can depend on a feature's properties. The SLDReader only supports dynamic values with PropertyName elements in these cases:

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -1744,7 +1744,7 @@
     var offsetX = displacement.displacementx ? displacement.displacementx : 0;
     var offsetY = displacement.displacementy ? displacement.displacementy : 0;
 
-    // Halo styling
+    // Assemble text style options.
     var textStyleOptions = {
       text: labelText,
       font: (fontStyle + " " + fontWeight + " " + fontSize + "px " + fontFamily),
@@ -1761,6 +1761,7 @@
       }),
     };
 
+    // Convert SLD halo to text symbol stroke.
     if (textsymbolizer.halo) {
       textStyleOptions.stroke = new style.Stroke({
         color:
@@ -1815,7 +1816,7 @@
       olText.setRotation((Math.PI * labelRotationDegrees) / 180.0); // OL rotation is in radians.
     }
 
-    // Set placement dynamically.
+    // Set line or point placement according to geometry type.
     var geometry = feature.getGeometry
       ? feature.getGeometry()
       : feature.geometry;

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -1379,6 +1379,27 @@
     return childValues.join('');
   }
 
+  /**
+   * Utility function for evaluating dynamic expressions without a feature.
+   * If the expression is static, the expression value will be returned.
+   * If the expression is dynamic, defaultValue will be returned.
+   * If the expression is falsy, defaultValue will be returned.
+   * @param {object|string} expression SLD object expression (or string).
+   * @param {any} defaultValue Default value.
+   * @returns {any} The value of a static expression or default value if the expression is dynamic.
+   */
+  function expressionOrDefault(expression, defaultValue) {
+    if (!expression) {
+      return defaultValue;
+    }
+
+    if (expression.type === 'expression') {
+      return defaultValue;
+    }
+
+    return expression;
+  }
+
   /* eslint-disable no-underscore-dangle */
 
   /**
@@ -1425,20 +1446,10 @@
     var style$1 = pointsymbolizer.graphic;
 
     // If the point size is a dynamic expression, use the default point size and update in-place later.
-    var pointSizeValue;
-    if (style$1.size && style$1.size.type === 'expression') {
-      pointSizeValue = DEFAULT_POINT_SIZE;
-    } else {
-      pointSizeValue = style$1.size || DEFAULT_POINT_SIZE;
-    }
+    var pointSizeValue = expressionOrDefault(style$1.size, DEFAULT_POINT_SIZE);
 
     // If the point rotation is a dynamic expression, use 0 as default rotation and update in-place later.
-    var rotationDegrees;
-    if (style$1.rotation && style$1.rotation.type === 'expression') {
-      rotationDegrees = 0.0;
-    } else {
-      rotationDegrees = style$1.rotation || 0.0;
-    }
+    var rotationDegrees = expressionOrDefault(style$1.rotation, 0.0);
 
     if (style$1.externalgraphic && style$1.externalgraphic.onlineresource) {
       // Check symbolizer metadata to see if the image has already been loaded.
@@ -1696,12 +1707,7 @@
 
     // If the label is dynamic, set text to empty string.
     // In that case, text will be set at runtime.
-    var labelText;
-    if (textsymbolizer.label.type === 'expression') {
-      labelText = '';
-    } else {
-      labelText = textsymbolizer.label;
-    }
+    var labelText = expressionOrDefault(textsymbolizer.label, '');
 
     var fill = textsymbolizer.fill ? textsymbolizer.fill.styling : {};
     var halo =
@@ -1729,13 +1735,7 @@
         : {};
 
     // If rotation is dynamic, default to 0. Rotation will be set at runtime.
-    var pointPlacementRotation = pointplacement.rotation || 0.0;
-    var labelRotationDegrees;
-    if (pointPlacementRotation.type === 'expression') {
-      labelRotationDegrees = 0.0;
-    } else {
-      labelRotationDegrees = pointPlacementRotation || 0.0;
-    }
+    var labelRotationDegrees = expressionOrDefault(pointplacement.rotation, 0.0);
 
     var displacement =
       pointplacement && pointplacement.displacement

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -1695,7 +1695,7 @@
     }
 
     // If the label is dynamic, set text to empty string.
-    // In that case, text will be set at run time.
+    // In that case, text will be set at runtime.
     var labelText;
     if (textsymbolizer.label.type === 'expression') {
       labelText = '';
@@ -1727,6 +1727,16 @@
       textsymbolizer.labelplacement.pointplacement
         ? textsymbolizer.labelplacement.pointplacement
         : {};
+
+    // If rotation is dynamic, default to 0. Rotation will be set at runtime.
+    var pointPlacementRotation = pointplacement.rotation || 0.0;
+    var labelRotationDegrees;
+    if (pointPlacementRotation.type === 'expression') {
+      labelRotationDegrees = 0.0;
+    } else {
+      labelRotationDegrees = pointPlacementRotation || 0.0;
+    }
+
     var displacement =
       pointplacement && pointplacement.displacement
         ? pointplacement.displacement
@@ -1734,15 +1744,13 @@
     var offsetX = displacement.displacementx ? displacement.displacementx : 0;
     var offsetY = displacement.displacementy ? displacement.displacementy : 0;
 
-    var rotation = pointplacement.rotation ? pointplacement.rotation : 0;
-
     // Halo styling
     var textStyleOptions = {
       text: labelText,
       font: (fontStyle + " " + fontWeight + " " + fontSize + "px " + fontFamily),
       offsetX: Number(offsetX),
       offsetY: Number(offsetY),
-      rotation: rotation,
+      rotation: (Math.PI * labelRotationDegrees) / 180.0,
       textAlign: 'center',
       textBaseline: 'middle',
       fill: new style.Fill({
@@ -1790,11 +1798,21 @@
 
     // Read text from feature and set it on the text style instance.
     var label = symbolizer.label;
+    var labelplacement = symbolizer.labelplacement;
 
     // Set text only if the label expression is dynamic.
     if (label.type === 'expression') {
       var labelText = evaluate(label, feature);
       olText.setText(labelText);
+    }
+
+    // Set rotation if expression is dynamic.
+    var pointPlacementRotation =
+      (labelplacement.pointplacement && labelplacement.pointplacement.rotation) ||
+      0.0;
+    if (pointPlacementRotation.type === 'expression') {
+      var labelRotationDegrees = evaluate(pointPlacementRotation, feature);
+      olText.setRotation((Math.PI * labelRotationDegrees) / 180.0); // OL rotation is in radians.
     }
 
     // Set placement dynamically.

--- a/src/olEvaluator.js
+++ b/src/olEvaluator.js
@@ -47,3 +47,24 @@ export default function evaluate(expression, feature) {
   }
   return childValues.join('');
 }
+
+/**
+ * Utility function for evaluating dynamic expressions without a feature.
+ * If the expression is static, the expression value will be returned.
+ * If the expression is dynamic, defaultValue will be returned.
+ * If the expression is falsy, defaultValue will be returned.
+ * @param {object|string} expression SLD object expression (or string).
+ * @param {any} defaultValue Default value.
+ * @returns {any} The value of a static expression or default value if the expression is dynamic.
+ */
+export function expressionOrDefault(expression, defaultValue) {
+  if (!expression) {
+    return defaultValue;
+  }
+
+  if (expression.type === 'expression') {
+    return defaultValue;
+  }
+
+  return expression;
+}

--- a/src/styles/pointStyle.js
+++ b/src/styles/pointStyle.js
@@ -11,7 +11,7 @@ import { memoizeStyleFunction } from './styleUtils';
 import { imageLoadingPointStyle, imageErrorPointStyle } from './static';
 import { createCachedImageStyle } from '../imageCache';
 import getWellKnownSymbol from './wellknown';
-import evaluate from '../olEvaluator';
+import evaluate, { expressionOrDefault } from '../olEvaluator';
 
 /**
  * @private
@@ -55,20 +55,10 @@ function pointStyle(pointsymbolizer) {
   const { graphic: style } = pointsymbolizer;
 
   // If the point size is a dynamic expression, use the default point size and update in-place later.
-  let pointSizeValue;
-  if (style.size && style.size.type === 'expression') {
-    pointSizeValue = DEFAULT_POINT_SIZE;
-  } else {
-    pointSizeValue = style.size || DEFAULT_POINT_SIZE;
-  }
+  const pointSizeValue = expressionOrDefault(style.size, DEFAULT_POINT_SIZE);
 
   // If the point rotation is a dynamic expression, use 0 as default rotation and update in-place later.
-  let rotationDegrees;
-  if (style.rotation && style.rotation.type === 'expression') {
-    rotationDegrees = 0.0;
-  } else {
-    rotationDegrees = style.rotation || 0.0;
-  }
+  const rotationDegrees = expressionOrDefault(style.rotation, 0.0);
 
   if (style.externalgraphic && style.externalgraphic.onlineresource) {
     // Check symbolizer metadata to see if the image has already been loaded.

--- a/src/styles/textStyle.js
+++ b/src/styles/textStyle.js
@@ -54,7 +54,7 @@ function textStyle(textsymbolizer) {
   const offsetX = displacement.displacementx ? displacement.displacementx : 0;
   const offsetY = displacement.displacementy ? displacement.displacementy : 0;
 
-  // Halo styling
+  // Assemble text style options.
   const textStyleOptions = {
     text: labelText,
     font: `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`,
@@ -71,6 +71,7 @@ function textStyle(textsymbolizer) {
     }),
   };
 
+  // Convert SLD halo to text symbol stroke.
   if (textsymbolizer.halo) {
     textStyleOptions.stroke = new Stroke({
       color:
@@ -124,7 +125,7 @@ function getTextStyle(symbolizer, feature) {
     olText.setRotation((Math.PI * labelRotationDegrees) / 180.0); // OL rotation is in radians.
   }
 
-  // Set placement dynamically.
+  // Set line or point placement according to geometry type.
   const geometry = feature.getGeometry
     ? feature.getGeometry()
     : feature.geometry;

--- a/src/styles/textStyle.js
+++ b/src/styles/textStyle.js
@@ -15,7 +15,7 @@ function textStyle(textsymbolizer) {
   }
 
   // If the label is dynamic, set text to empty string.
-  // In that case, text will be set at run time.
+  // In that case, text will be set at runtime.
   let labelText;
   if (textsymbolizer.label.type === 'expression') {
     labelText = '';
@@ -48,6 +48,16 @@ function textStyle(textsymbolizer) {
     textsymbolizer.labelplacement.pointplacement
       ? textsymbolizer.labelplacement.pointplacement
       : {};
+
+  // If rotation is dynamic, default to 0. Rotation will be set at runtime.
+  const pointPlacementRotation = pointplacement.rotation || 0.0;
+  let labelRotationDegrees;
+  if (pointPlacementRotation.type === 'expression') {
+    labelRotationDegrees = 0.0;
+  } else {
+    labelRotationDegrees = pointPlacementRotation || 0.0;
+  }
+
   const displacement =
     pointplacement && pointplacement.displacement
       ? pointplacement.displacement
@@ -55,15 +65,13 @@ function textStyle(textsymbolizer) {
   const offsetX = displacement.displacementx ? displacement.displacementx : 0;
   const offsetY = displacement.displacementy ? displacement.displacementy : 0;
 
-  const rotation = pointplacement.rotation ? pointplacement.rotation : 0;
-
   // Halo styling
   const textStyleOptions = {
     text: labelText,
     font: `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`,
     offsetX: Number(offsetX),
     offsetY: Number(offsetY),
-    rotation,
+    rotation: (Math.PI * labelRotationDegrees) / 180.0,
     textAlign: 'center',
     textBaseline: 'middle',
     fill: new Fill({
@@ -110,12 +118,21 @@ function getTextStyle(symbolizer, feature) {
   }
 
   // Read text from feature and set it on the text style instance.
-  const { label } = symbolizer;
+  const { label, labelplacement } = symbolizer;
 
   // Set text only if the label expression is dynamic.
   if (label.type === 'expression') {
     const labelText = evaluate(label, feature);
     olText.setText(labelText);
+  }
+
+  // Set rotation if expression is dynamic.
+  const pointPlacementRotation =
+    (labelplacement.pointplacement && labelplacement.pointplacement.rotation) ||
+    0.0;
+  if (pointPlacementRotation.type === 'expression') {
+    const labelRotationDegrees = evaluate(pointPlacementRotation, feature);
+    olText.setRotation((Math.PI * labelRotationDegrees) / 180.0); // OL rotation is in radians.
   }
 
   // Set placement dynamically.

--- a/src/styles/textStyle.js
+++ b/src/styles/textStyle.js
@@ -1,6 +1,6 @@
 import { Style, Fill, Stroke, Text } from 'ol/style';
 import { hexToRGB, memoizeStyleFunction } from './styleUtils';
-import evaluate from '../olEvaluator';
+import evaluate, { expressionOrDefault } from '../olEvaluator';
 
 /**
  * @private
@@ -16,12 +16,7 @@ function textStyle(textsymbolizer) {
 
   // If the label is dynamic, set text to empty string.
   // In that case, text will be set at runtime.
-  let labelText;
-  if (textsymbolizer.label.type === 'expression') {
-    labelText = '';
-  } else {
-    labelText = textsymbolizer.label;
-  }
+  const labelText = expressionOrDefault(textsymbolizer.label, '');
 
   const fill = textsymbolizer.fill ? textsymbolizer.fill.styling : {};
   const halo =
@@ -50,13 +45,7 @@ function textStyle(textsymbolizer) {
       : {};
 
   // If rotation is dynamic, default to 0. Rotation will be set at runtime.
-  const pointPlacementRotation = pointplacement.rotation || 0.0;
-  let labelRotationDegrees;
-  if (pointPlacementRotation.type === 'expression') {
-    labelRotationDegrees = 0.0;
-  } else {
-    labelRotationDegrees = pointPlacementRotation || 0.0;
-  }
+  const labelRotationDegrees = expressionOrDefault(pointplacement.rotation, 0.0);
 
   const displacement =
     pointplacement && pointplacement.displacement

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -266,12 +266,21 @@ describe('Dynamic style properties', () => {
 
   it('Reads rotation from feature', () => {
     const style = styleFunction(pointFeature)[0];
-    expect(style.getImage().getRotation()).to.equal((Math.PI * 42.0) / 180.0); // OL rotation is in radians.
+    // OL rotation is in radians.
+    expect(style.getImage().getRotation()).to.equal((Math.PI * 42.0) / 180.0);
   });
 
   it('Reads text for label from feature', () => {
     const textStyle = styleFunction(pointFeature)[1];
     expect(textStyle.getText().getText()).to.equal('This is a test');
+  });
+
+  it('Reads label rotation from feature', () => {
+    const textStyle = styleFunction(pointFeature)[1];
+    // OL rotation is in radians.
+    expect(textStyle.getText().getRotation()).to.equal(
+      (Math.PI * 42.0) / 180.0
+    );
   });
 
   it('Sets label placement according to feature geometry type', () => {

--- a/test/data/dynamic.sld.js
+++ b/test/data/dynamic.sld.js
@@ -46,6 +46,9 @@ export const dynamicSld = `<?xml version="1.0" encoding="UTF-8"?>
             </sld:Halo>
             <sld:LabelPlacement>
               <sld:PointPlacement>
+                <sld:Rotation>
+                  <ogc:PropertyName>angle</ogc:PropertyName>
+                </sld:Rotation>
                 <sld:AnchorPoint>
                   <sld:AnchorPointX>0</sld:AnchorPointX>
                   <sld:AnchorPointY>0.5</sld:AnchorPointY>


### PR DESCRIPTION
This pull request addresses two issues with label rotation within PointPlacement section.
* Angles are now properly converted to radians used by OpenLayers.
* It's possible to use ogc:PropertyName with a label rotation element.