### PR TITLE
Fix handling TextSymbolizer without LabelPlacement

### DIFF
--- a/src/styles/static.js
+++ b/src/styles/static.js
@@ -1,5 +1,7 @@
 import { Style, Fill, Stroke, Circle, RegularShape } from 'ol/style';
 
+export const emptyStyle = new Style({});
+
 export const defaultPointStyle = new Style({
   image: new Circle({
     radius: 8,

--- a/src/styles/textStyle.js
+++ b/src/styles/textStyle.js
@@ -1,6 +1,7 @@
 import { Style, Fill, Stroke, Text } from 'ol/style';
 import { hexToRGB, memoizeStyleFunction } from './styleUtils';
 import evaluate, { expressionOrDefault } from '../olEvaluator';
+import { emptyStyle } from './static';
 
 /**
  * @private
@@ -11,7 +12,7 @@ import evaluate, { expressionOrDefault } from '../olEvaluator';
  */
 function textStyle(textsymbolizer) {
   if (!(textsymbolizer && textsymbolizer.label)) {
-    return new Style({});
+    return emptyStyle;
   }
 
   // If the label is dynamic, set text to empty string.
@@ -45,7 +46,10 @@ function textStyle(textsymbolizer) {
       : {};
 
   // If rotation is dynamic, default to 0. Rotation will be set at runtime.
-  const labelRotationDegrees = expressionOrDefault(pointplacement.rotation, 0.0);
+  const labelRotationDegrees = expressionOrDefault(
+    pointplacement.rotation,
+    0.0
+  );
 
   const displacement =
     pointplacement && pointplacement.displacement
@@ -111,18 +115,21 @@ function getTextStyle(symbolizer, feature) {
   const { label, labelplacement } = symbolizer;
 
   // Set text only if the label expression is dynamic.
-  if (label.type === 'expression') {
+  if (label && label.type === 'expression') {
     const labelText = evaluate(label, feature);
     olText.setText(labelText);
   }
 
   // Set rotation if expression is dynamic.
-  const pointPlacementRotation =
-    (labelplacement.pointplacement && labelplacement.pointplacement.rotation) ||
-    0.0;
-  if (pointPlacementRotation.type === 'expression') {
-    const labelRotationDegrees = evaluate(pointPlacementRotation, feature);
-    olText.setRotation((Math.PI * labelRotationDegrees) / 180.0); // OL rotation is in radians.
+  if (labelplacement) {
+    const pointPlacementRotation =
+      (labelplacement.pointplacement &&
+        labelplacement.pointplacement.rotation) ||
+      0.0;
+    if (pointPlacementRotation.type === 'expression') {
+      const labelRotationDegrees = evaluate(pointPlacementRotation, feature);
+      olText.setRotation((Math.PI * labelRotationDegrees) / 180.0); // OL rotation is in radians.
+    }
   }
 
   // Set line or point placement according to geometry type.

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -10,12 +10,13 @@ import { sld } from './data/test.sld';
 import { sld11 } from './data/test11.sld';
 import { externalGraphicSld } from './data/externalgraphic.sld';
 import { dynamicSld } from './data/dynamic.sld';
+import { textSymbolizerSld } from './data/textSymbolizer.sld';
 import { IMAGE_LOADING, IMAGE_LOADED } from '../src/constants';
 
-const getFeature = type => ({
+const getMockOLFeature = geometryType => ({
   properties: {},
   geometry: {
-    type,
+    type: geometryType,
   },
 });
 
@@ -44,23 +45,23 @@ describe('create ol style object from styledescription', () => {
   };
 
   it('returns array', () => {
-    const style = OlStyler(styleDescription, getFeature('Polygon'));
+    const style = OlStyler(styleDescription, getMockOLFeature('Polygon'));
     expect(style).to.be.an('array');
   });
   it('returns object with polygon style', () => {
-    const style = OlStyler(styleDescription, getFeature('Polygon'));
+    const style = OlStyler(styleDescription, getMockOLFeature('Polygon'));
     expect(style['0']).to.be.an.instanceof(Style);
   });
   it('returns object with polygon fill', () => {
-    const style = OlStyler(styleDescription, getFeature('Polygon'));
+    const style = OlStyler(styleDescription, getMockOLFeature('Polygon'));
     expect(style['0'].getFill().getColor()).to.equal('blue');
   });
   it('returns object linestring style', () => {
-    const style = OlStyler(styleDescription, getFeature('LineString'));
+    const style = OlStyler(styleDescription, getMockOLFeature('LineString'));
     expect(style['0']).to.be.an.instanceof(Style);
   });
   it('returns object with polygon fill', () => {
-    const style = OlStyler(styleDescription, getFeature('LineString'));
+    const style = OlStyler(styleDescription, getMockOLFeature('LineString'));
     expect(style['0'].getStroke().getColor()).to.equal('red');
   });
 });
@@ -86,11 +87,11 @@ describe('creates point style', () => {
     ],
   };
   it('returns array', () => {
-    const style = OlStyler(styleDescription, getFeature('Point'));
+    const style = OlStyler(styleDescription, getMockOLFeature('Point'));
     expect(style).to.be.an('array');
   });
   it('returns style', () => {
-    const style = OlStyler(styleDescription, getFeature('Point'));
+    const style = OlStyler(styleDescription, getMockOLFeature('Point'));
     expect(style['0']).to.be.an.instanceOf(Style);
   });
 });
@@ -107,7 +108,15 @@ describe('Create OL Style function from SLD feature type style', () => {
     type: 'Feature',
     geometry: {
       type: 'Polygon',
-      coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+      coordinates: [
+        [
+          [0, 0],
+          [1, 0],
+          [1, 1],
+          [0, 1],
+          [0, 0],
+        ],
+      ],
     },
     properties: {
       provincienaam: 'Gelderland',
@@ -286,5 +295,35 @@ describe('Dynamic style properties', () => {
   it('Sets label placement according to feature geometry type', () => {
     const textStyle = styleFunction(pointFeature)[1];
     expect(textStyle.getText().getPlacement()).to.equal('point');
+  });
+});
+
+describe('Text symbolizer', () => {
+  const geojson = {
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [175135, 441200],
+    },
+    properties: {
+      size: 100,
+      angle: 42,
+      title: 'This is a test',
+    },
+  };
+
+  let pointFeature;
+  let styleFunction;
+  before(() => {
+    const fmtGeoJSON = new OLFormatGeoJSON();
+    pointFeature = fmtGeoJSON.readFeature(geojson);
+    const sldObject = Reader(textSymbolizerSld);
+    const [featureTypeStyle] = sldObject.layers[0].styles[0].featuretypestyles;
+    styleFunction = createOlStyleFunction(featureTypeStyle);
+  });
+
+  it('Handles TextSymbolizer with only a Label', () => {
+    const textStyle = styleFunction(pointFeature)[0];
+    expect(textStyle.getText().getText()).to.equal('TEST');
   });
 });

--- a/test/data/textSymbolizer.sld.js
+++ b/test/data/textSymbolizer.sld.js
@@ -1,0 +1,22 @@
+export const textSymbolizerSld = `<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" 
+  xmlns:sld="http://www.opengis.net/sld" 
+  xmlns:ogc="http://www.opengis.net/ogc" 
+  xmlns:gml="http://www.opengis.net/gml" 
+  xmlns:xlink="http://www.w3.org/1999/xlink" version="1.0.0">
+  <NamedLayer>
+    <Name>test_minimal_symbolizers</Name>
+    <UserStyle>
+      <Name>test_minimal_symbolizers</Name>
+      <FeatureTypeStyle>
+        <Rule>
+          <TextSymbolizer>
+            <Label>TEST</Label>
+          </TextSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>`;
+
+export default textSymbolizerSld;


### PR DESCRIPTION
This pull request fixes a fatal crash at runtime in the generated style function when using a TextSymbolizer without an (optional) LabelPlacement element.
