### PR TITLE
Fix labeling regressions

### DIFF
--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -2278,7 +2278,8 @@
     // Set text only if the label expression is dynamic.
     if (label && label.type === 'expression') {
       var labelText = evaluate(label, feature);
-      olText.setText(labelText);
+      // Important! OpenLayers expects the text property to always be a string.
+      olText.setText(labelText.toString());
     }
 
     // Set rotation if expression is dynamic.

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -465,7 +465,7 @@
     Graphic: addProp,
     ExternalGraphic: addProp,
     Mark: addProp,
-    Label: addFilterExpressionProp,
+    Label: function (node, obj, prop) { return addFilterExpressionProp(node, obj, prop, false); },
     Halo: addProp,
     Font: addProp,
     Radius: addPropWithTextContent,

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -205,7 +205,7 @@ const SymbParsers = {
   Graphic: addProp,
   ExternalGraphic: addProp,
   Mark: addProp,
-  Label: addFilterExpressionProp,
+  Label: (node, obj, prop) => addFilterExpressionProp(node, obj, prop, false),
   Halo: addProp,
   Font: addProp,
   Radius: addPropWithTextContent,

--- a/src/styles/textStyle.js
+++ b/src/styles/textStyle.js
@@ -117,7 +117,8 @@ function getTextStyle(symbolizer, feature) {
   // Set text only if the label expression is dynamic.
   if (label && label.type === 'expression') {
     const labelText = evaluate(label, feature);
-    olText.setText(labelText);
+    // Important! OpenLayers expects the text property to always be a string.
+    olText.setText(labelText.toString());
   }
 
   // Set rotation if expression is dynamic.

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -11,6 +11,7 @@ import { externalGraphicSld } from './data/externalgraphic.sld';
 import { dynamicSld } from './data/dynamic.sld';
 import { textSymbolizerSld } from './data/textSymbolizer.sld';
 import { textSymbolizerDynamicSld } from './data/textSymbolizer-dynamic.sld';
+import { textSymbolizerCDataSld } from './data/textSymbolizer-cdata.sld';
 import { externalGraphicStrokeSld } from './data/external-graphicstroke.sld';
 import { IMAGE_LOADING, IMAGE_LOADED } from '../src/constants';
 import {
@@ -400,5 +401,14 @@ describe('Text symbolizer', () => {
     const textStyle = styleFunction(pointFeature)[0];
     // Important: for formatting longer text, OL expects that the text property is always a string.
     expect(textStyle.getText().getText()).to.equal('100');
+  });
+
+  it('Text symbolizer with CDATA sections', () => {
+    const sldObject = Reader(textSymbolizerCDataSld);
+    const [featureTypeStyle] = sldObject.layers[0].styles[0].featuretypestyles;
+    const styleFunction = createOlStyleFunction(featureTypeStyle);
+    const textStyle = styleFunction(pointFeature)[0];
+    // CDATA whitespace should be kept intact.
+    expect(textStyle.getText().getText()).to.equal('Size: 100\nAngle: 42');
   });
 });

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -10,6 +10,7 @@ import { sld11 } from './data/test11.sld';
 import { externalGraphicSld } from './data/externalgraphic.sld';
 import { dynamicSld } from './data/dynamic.sld';
 import { textSymbolizerSld } from './data/textSymbolizer.sld';
+import { textSymbolizerDynamicSld } from './data/textSymbolizer-dynamic.sld';
 import { externalGraphicStrokeSld } from './data/external-graphicstroke.sld';
 import { IMAGE_LOADING, IMAGE_LOADED } from '../src/constants';
 import {
@@ -379,17 +380,25 @@ describe('Text symbolizer', () => {
   };
 
   let pointFeature;
-  let styleFunction;
   before(() => {
     const fmtGeoJSON = new OLFormatGeoJSON();
     pointFeature = fmtGeoJSON.readFeature(geojson);
-    const sldObject = Reader(textSymbolizerSld);
-    const [featureTypeStyle] = sldObject.layers[0].styles[0].featuretypestyles;
-    styleFunction = createOlStyleFunction(featureTypeStyle);
   });
 
   it('Handles TextSymbolizer with only a Label', () => {
+    const sldObject = Reader(textSymbolizerSld);
+    const [featureTypeStyle] = sldObject.layers[0].styles[0].featuretypestyles;
+    const styleFunction = createOlStyleFunction(featureTypeStyle);
     const textStyle = styleFunction(pointFeature)[0];
     expect(textStyle.getText().getText()).to.equal('TEST');
+  });
+
+  it('Text symbolizer with dynamic label containing a number', () => {
+    const sldObject = Reader(textSymbolizerDynamicSld);
+    const [featureTypeStyle] = sldObject.layers[0].styles[0].featuretypestyles;
+    const styleFunction = createOlStyleFunction(featureTypeStyle);
+    const textStyle = styleFunction(pointFeature)[0];
+    // Important: for formatting longer text, OL expects that the text property is always a string.
+    expect(textStyle.getText().getText()).to.equal('100');
   });
 });

--- a/test/data/textSymbolizer-cdata.sld.js
+++ b/test/data/textSymbolizer-cdata.sld.js
@@ -1,0 +1,24 @@
+export const textSymbolizerCDataSld = `<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" 
+  xmlns:sld="http://www.opengis.net/sld" 
+  xmlns:ogc="http://www.opengis.net/ogc" 
+  xmlns:gml="http://www.opengis.net/gml" 
+  xmlns:xlink="http://www.w3.org/1999/xlink" version="1.0.0">
+  <NamedLayer>
+    <Name>test_minimal_symbolizers</Name>
+    <UserStyle>
+      <Name>test_minimal_symbolizers</Name>
+      <FeatureTypeStyle>
+        <Rule>
+          <TextSymbolizer>
+            <Label>Size:<![CDATA[ ]]><ogc:PropertyName>size</ogc:PropertyName><![CDATA[
+]]>Angle:<![CDATA[ ]]><ogc:PropertyName>angle</ogc:PropertyName>
+            </Label>
+          </TextSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>`;
+
+export default textSymbolizerCDataSld;

--- a/test/data/textSymbolizer-dynamic.sld.js
+++ b/test/data/textSymbolizer-dynamic.sld.js
@@ -1,0 +1,22 @@
+export const textSymbolizerDynamicSld = `<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" 
+  xmlns:sld="http://www.opengis.net/sld" 
+  xmlns:ogc="http://www.opengis.net/ogc" 
+  xmlns:gml="http://www.opengis.net/gml" 
+  xmlns:xlink="http://www.w3.org/1999/xlink" version="1.0.0">
+  <NamedLayer>
+    <Name>test_minimal_symbolizers</Name>
+    <UserStyle>
+      <Name>test_minimal_symbolizers</Name>
+      <FeatureTypeStyle>
+        <Rule>
+          <TextSymbolizer>
+            <Label><ogc:PropertyName>size</ogc:PropertyName></Label>
+          </TextSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>`;
+
+export default textSymbolizerDynamicSld;


### PR DESCRIPTION
This pull request fixes two TextSymbolizer bugs:
* Whitespace-only CDATA text is stripped out of the label.
* Polygon labels using a numeric property value cause an error in the style function.

Fixes #68