### PR TITLE
Fix ElseFilter evaluation

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -61,20 +61,36 @@ export function getStyle(layer, name) {
  * @return {Rule[]}
  */
 export function getRules(featureTypeStyle, feature, resolution, options = {}) {
-  const result = [];
+  const validRules = [];
+  let elseFilterCount = 0;
   for (let j = 0; j < featureTypeStyle.rules.length; j += 1) {
     const rule = featureTypeStyle.rules[j];
+    // Only keep rules that pass the rule's min/max scale denominator checks.
     if (scaleSelector(rule, resolution)) {
-      if (rule.filter && filterSelector(rule.filter, feature, options)) {
-        result.push(rule);
-      } else if (rule.elsefilter && result.length === 0) {
-        result.push(rule);
-      } else if (!rule.elsefilter && !rule.filter) {
-        result.push(rule);
+      if (rule.elsefilter) {
+        // In the first rule selection step, keep all rules with an ElseFilter.
+        validRules.push(rule);
+        elseFilterCount += 1;
+      } else if (!rule.filter) {
+        // Rules without filter always apply.
+        validRules.push(rule);
+      } else if (filterSelector(rule.filter, feature, options)) {
+        // If a rule has a filter, only keep it if the feature passes the filter.
+        validRules.push(rule);
       }
     }
   }
-  return result;
+
+  // When eligible rules contain only rules with ElseFilter, return them all.
+  // Note: the spec does not forbid more than one ElseFilter remaining at a given scale,
+  // but leaves handling this case up to the implementor.
+  // The SLDLibrary chooses to keep them all.
+  if (elseFilterCount === validRules.length) {
+    return validRules;
+  }
+
+  // If a mix of rules with and without ElseFilter remains, only keep rules without ElseFilter.
+  return validRules.filter(rule => !rule.elsefilter);
 }
 
 /**


### PR DESCRIPTION
If an SLD contains a rule with an ElseFilter before another valid rule, the symbolizer of both rules are rendered.

This pull request fixes the handling of rules with an ElseFilter, so rules with an ElseFilter are never drawn if any other rule passes.