### PR TITLE
Apply LineSymbolizer to polygon outlines

### DIFF
--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -2479,8 +2479,11 @@
         for (var i = 0; i < polygon.length; i += 1) {
           appendStyle(styles, polygon[i], feature, getPolygonStyle);
         }
-        for (var j$4 = 0; j$4 < text.length; j$4 += 1) {
-          styles.push(getTextStyle(text[j$4], feature));
+        for (var j$4 = 0; j$4 < line.length; j$4 += 1) {
+          appendStyle(styles, line[j$4], feature, getLineStyle);
+        }
+        for (var k = 0; k < text.length; k += 1) {
+          styles.push(getTextStyle(text[k], feature));
         }
         break;
 

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -71,8 +71,11 @@ export default function OlStyler(GeometryStyles, feature) {
       for (let i = 0; i < polygon.length; i += 1) {
         appendStyle(styles, polygon[i], feature, getPolygonStyle);
       }
-      for (let j = 0; j < text.length; j += 1) {
-        styles.push(getTextStyle(text[j], feature));
+      for (let j = 0; j < line.length; j += 1) {
+        appendStyle(styles, line[j], feature, getLineStyle);
+      }
+      for (let k = 0; k < text.length; k += 1) {
+        styles.push(getTextStyle(text[k], feature));
       }
       break;
 

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -14,6 +14,8 @@ import { textSymbolizerDynamicSld } from './data/textSymbolizer-dynamic.sld';
 import { textSymbolizerCDataSld } from './data/textSymbolizer-cdata.sld';
 import { externalGraphicStrokeSld } from './data/external-graphicstroke.sld';
 import { polyGraphicFillAndStrokeSld } from './data/poly-graphic-fill-and-stroke';
+import { simpleLineSymbolizerSld } from './data/simple-line-symbolizer.sld';
+
 import { IMAGE_LOADING, IMAGE_LOADED } from '../src/constants';
 import {
   clearImageCache,
@@ -373,6 +375,7 @@ describe('Dynamic style properties', () => {
   before(() => {
     const fmtGeoJSON = new OLFormatGeoJSON();
     pointFeature = fmtGeoJSON.readFeature(geojson);
+
     const sldObject = Reader(dynamicSld);
     [featureTypeStyle] = sldObject.layers[0].styles[0].featuretypestyles;
     styleFunction = createOlStyleFunction(featureTypeStyle);
@@ -452,5 +455,37 @@ describe('Text symbolizer', () => {
     const textStyle = styleFunction(pointFeature)[0];
     // CDATA whitespace should be kept intact.
     expect(textStyle.getText().getText()).to.equal('Size: 100\nAngle: 42');
+  });
+});
+
+describe('Polygon styling', () => {
+  const geojson = {
+    type: 'Feature',
+    geometry: {
+      type: 'Polygon',
+      // prettier-ignore
+      coordinates: [[[0, 0], [0, 100], [100, 100], [100, 0], [0, 0]]],
+    },
+    properties: {
+      size: 100,
+      angle: 42,
+      title: 'This is a test',
+    },
+  };
+
+  let polygonFeature;
+  before(() => {
+    const fmtGeoJSON = new OLFormatGeoJSON();
+    polygonFeature = fmtGeoJSON.readFeature(geojson);
+  });
+
+  // When a rule contains a LineSymbolizer, it should be applied to a polygon outline.
+  it('Applies LineSymbolizer to polygon outline', () => {
+    const sldObject = Reader(simpleLineSymbolizerSld);
+    const [featureTypeStyle] = sldObject.layers[0].styles[0].featuretypestyles;
+    const styleFunction = createOlStyleFunction(featureTypeStyle);
+    const olStyle = styleFunction(polygonFeature)[0];
+    expect(olStyle.getStroke().getColor()).to.equal('#FF0000');
+    expect(olStyle.getStroke().getWidth()).to.equal(1);
   });
 });

--- a/test/data/simple-line-symbolizer.sld.js
+++ b/test/data/simple-line-symbolizer.sld.js
@@ -1,0 +1,25 @@
+export const simpleLineSymbolizerSld = `<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" 
+  xmlns:ogc="http://www.opengis.net/ogc" 
+  xmlns:xlink="http://www.w3.org/1999/xlink" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>Line</Name>
+    <UserStyle>
+      <FeatureTypeStyle>
+        <Name>Simple line style</Name>
+        <Rule>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#FF0000</CssParameter>
+              <CssParameter name="stroke-width">1</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>
+`;
+
+export default simpleLineSymbolizerSld;


### PR DESCRIPTION
This fixes issue #91 where a LineSymbolizer is not applied to the outline of polygon features.