### PR TITLE
Fix image loaded callback

### DIFF
--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -1162,6 +1162,20 @@
     return imageLoadingStateCache[url];
   }
 
+  /**
+   * @private
+   * A cache of image loading promises.
+   * A map of image Url -> Promise
+   * This used to prevent duplicate loading when a style references an image that's already being loaded.
+   */
+  var _imageLoaderCache = {};
+  function getImageLoader(url) {
+    return _imageLoaderCache[url];
+  }
+  function setImageLoader(url, loaderPromise) {
+    _imageLoaderCache[url] = loaderPromise;
+  }
+
   function invalidateExternalGraphicSymbolizers(symbolizer, imageUrl) {
     // Look at all possible paths where an externalgraphic may be present within a symbolizer.
     // When such an externalgraphic has been found, and its url equals imageUrl, invalidate the symbolizer.
@@ -1216,8 +1230,54 @@
 
   /**
    * @private
-   * Load and cache an image that's used as externalGraphic inside one or more symbolizers inside a feature type style object.
-   * When the image is loaded, the symbolizers with ExternalGraphics pointing to the image are invalidated,
+   * Creates a promise that loads an image and store it in the image cache.
+   * Calling this method with the same image url twice will return the loader promise
+   * that was created when this method was called the first time for that specific image url.
+   * @param {string} imageUrl Image url.
+   * @returns {Promise} A promise that resolves when the image is loaded and fails when the
+   * image didn't load correctly.
+   */
+  function getCachingImageLoader(imageUrl) {
+    // Check of a load is already in progress for an image.
+    // If so, return the loader.
+    var loader = getImageLoader(imageUrl);
+    if (loader) {
+      return loader;
+    }
+
+    // If no load is in progress, create a new loader and store it in the image loader cache before returning it.
+    loader = new Promise(function (resolve, reject) {
+      var image = new Image();
+
+      image.onload = function () {
+        setCachedImage(imageUrl, {
+          url: imageUrl,
+          image: image,
+          width: image.naturalWidth,
+          height: image.naturalHeight,
+        });
+        setImageLoadingState(imageUrl, IMAGE_LOADED);
+        resolve(imageUrl);
+      };
+
+      image.onerror = function () {
+        setImageLoadingState(imageUrl, IMAGE_ERROR);
+        reject();
+      };
+
+      image.src = imageUrl;
+    });
+
+    // Cache the new image loader and return it.
+    setImageLoadingState(imageUrl, IMAGE_LOADING);
+    setImageLoader(imageUrl, loader);
+    return loader;
+  }
+
+  /**
+   * @private
+   * Load and cache an image that's used as externalGraphic inside a symbolizer.
+   * When the image is loaded, all symbolizers within the feature type style referencing this image are invalidated,
    * and the imageLoadedCallback is called with the loaded image url.
    * @param {url} imageUrl Image url.
    * @param {object} featureTypeStyle Feature type style object.
@@ -1229,33 +1289,20 @@
     featureTypeStyle,
     imageLoadedCallback
   ) {
-    var image = new Image();
-
-    image.onload = function () {
-      setCachedImage(imageUrl, {
-        url: imageUrl,
-        image: image,
-        width: image.naturalWidth,
-        height: image.naturalHeight,
-      });
-      setImageLoadingState(imageUrl, IMAGE_LOADED);
-      invalidateExternalGraphics(featureTypeStyle, imageUrl);
-      if (typeof imageLoadedCallback === 'function') {
-        imageLoadedCallback(imageUrl);
-      }
-    };
-
-    image.onerror = function () {
-      setImageLoadingState(imageUrl, IMAGE_ERROR);
-      invalidateExternalGraphics(featureTypeStyle, imageUrl);
-      if (typeof imageLoadedCallback === 'function') {
-        imageLoadedCallback();
-      }
-    };
-
-    image.src = imageUrl;
-    setImageLoadingState(imageUrl, IMAGE_LOADING);
     invalidateExternalGraphics(featureTypeStyle, imageUrl);
+    getCachingImageLoader(imageUrl)
+      .then(function () {
+        invalidateExternalGraphics(featureTypeStyle, imageUrl);
+        if (typeof imageLoadedCallback === 'function') {
+          imageLoadedCallback(imageUrl);
+        }
+      })
+      .catch(function () {
+        invalidateExternalGraphics(featureTypeStyle, imageUrl);
+        if (typeof imageLoadedCallback === 'function') {
+          imageLoadedCallback();
+        }
+      });
   }
 
   /**
@@ -1268,7 +1315,8 @@
   function processExternalGraphicSymbolizers(
     rules,
     featureTypeStyle,
-    imageLoadedCallback
+    imageLoadedCallback,
+    callbackRef
   ) {
     // Walk over all symbolizers inside all given rules.
     // Dive into the symbolizers to find ExternalGraphic elements and for each ExternalGraphic,
@@ -1284,10 +1332,20 @@
           }
           var imageUrl = exgraphic.onlineresource;
           var imageLoadingState = getImageLoadingState(imageUrl);
-          if (!imageLoadingState) {
-            // Start loading the image and set image load state on the symbolizer.
-            setImageLoadingState(imageUrl, IMAGE_LOADING);
-            loadExternalGraphic(imageUrl, featureTypeStyle, imageLoadedCallback);
+          if (!imageLoadingState || imageLoadingState === IMAGE_LOADING) {
+            // Prevent adding imageLoadedCallback more than once per image per created style function
+            // by inspecting the callbackRef object passed by the style function creator function.
+            // Each style function has its own callbackRef dictionary.
+            if (!callbackRef[imageUrl]) {
+              callbackRef[imageUrl] = true;
+              // Load image and when loaded, invalidate all symbolizers referencing the image
+              // and invoke the imageLoadedCallback.
+              loadExternalGraphic(
+                imageUrl,
+                featureTypeStyle,
+                imageLoadedCallback
+              );
+            }
           }
         });
       });
@@ -2538,6 +2596,9 @@
 
     var imageLoadedCallback = options.imageLoadedCallback || (function () {});
 
+    // Keep track of whether a callback has been registered per image url.
+    var callbackRef = {};
+
     return function (feature, mapResolution) {
       // Determine resolution in meters/pixel.
       var resolution =
@@ -2557,7 +2618,8 @@
       processExternalGraphicSymbolizers(
         rules,
         featureTypeStyle,
-        imageLoadedCallback
+        imageLoadedCallback,
+        callbackRef
       );
 
       // Convert style rules to style rule lookup categorized by geometry type.

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -128,6 +128,9 @@ function getOlFeatureProperty(feature, propertyName) {
 export function createOlStyleFunction(featureTypeStyle, options = {}) {
   const imageLoadedCallback = options.imageLoadedCallback || (() => {});
 
+  // Keep track of whether a callback has been registered per image url.
+  const callbackRef = {};
+
   return (feature, mapResolution) => {
     // Determine resolution in meters/pixel.
     const resolution =
@@ -147,7 +150,8 @@ export function createOlStyleFunction(featureTypeStyle, options = {}) {
     processExternalGraphicSymbolizers(
       rules,
       featureTypeStyle,
-      imageLoadedCallback
+      imageLoadedCallback,
+      callbackRef
     );
 
     // Convert style rules to style rule lookup categorized by geometry type.

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -181,7 +181,7 @@ describe('Create OL Style function from SLD feature type style 1', () => {
   });
 });
 
-describe.only('SLD with external graphics', () => {
+describe('SLD with external graphics', () => {
   let featureTypeStyle;
   let featureTypeStyle2;
   beforeEach(() => {
@@ -419,10 +419,12 @@ describe.only('SLD with external graphics', () => {
     const styleFunction1 = createOlStyleFunction(featureTypeStyle);
     const styleFunction2 = createOlStyleFunction(featureTypeStyle2, {
       imageLoadedCallback: () => {
-        // When the second style function callback gets called, the pointsymbolizer of the second style object
-        // should also be properly invalidated.
-        const { pointsymbolizer } = featureTypeStyle2.rules[0];
-        expect(pointsymbolizer.__invalidated).to.be.true;
+        expect(featureTypeStyle.rules[1].pointsymbolizer.__invalidated).to.be
+          .true;
+        // The pointsymbolizer of the second style object should also be properly invalidated,
+        // even if it uses the same image for which the first style function triggered the loading.
+        expect(featureTypeStyle2.rules[0].pointsymbolizer.__invalidated).to.be
+          .true;
         done();
       },
     });

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -182,11 +182,13 @@ describe('Create OL Style function from SLD feature type style 1', () => {
 
 describe('SLD with external graphics', () => {
   let featureTypeStyle;
+  let featureTypeStyle2;
   beforeEach(() => {
     clearImageCache();
     clearImageLoadingStateCache();
     const sldObject = Reader(externalGraphicSld);
     [featureTypeStyle] = sldObject.layers[0].styles[0].featuretypestyles;
+    [featureTypeStyle2] = sldObject.layers[0].styles[1].featuretypestyles;
   });
 
   it('Only requests images for matching rules', () => {
@@ -267,6 +269,134 @@ describe('SLD with external graphics', () => {
 
     // Just call the style function to trigger image load.
     styleFunction(olFeature, null);
+  });
+
+  it('Calls imageLoadedCallback only once when multiple features are evaluated for style', done => {
+    const geojson = {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [175135, 441200],
+      },
+      properties: {
+        type: '2',
+      },
+    };
+
+    const fmtGeoJSON = new OLFormatGeoJSON();
+    const olFeature = fmtGeoJSON.readFeature(geojson);
+
+    let callbackCount = 0;
+    const styleFunction = createOlStyleFunction(featureTypeStyle, {
+      imageLoadedCallback: () => {
+        callbackCount += 1;
+      },
+    });
+
+    // Evaluate the style for multiple features in a row.
+    // ImageLoaded callback should be called only once.
+    styleFunction(olFeature, null);
+    styleFunction(olFeature, null);
+    styleFunction(olFeature, null);
+
+    setTimeout(() => {
+      expect(callbackCount).to.equal(1);
+      done();
+    }, 50);
+  });
+
+  // The two tests below reproduce the case where different style functions contain a symbolizer that points to the same image url.
+  // The imageLoadedCallback should be called for both style functions, even if they happen to display the same image.
+  //
+  // This can happen when:
+  // * Two (or more) style functions are created from the same feature type style.
+  // * Style functions are created from different feature type style that happen to contain the same image.
+  it('ImageLoadedCallback should be called for each style function created from the same style object', done => {
+    const geojson = {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [175135, 441200],
+      },
+      properties: {
+        type: '2',
+      },
+    };
+
+    const fmtGeoJSON = new OLFormatGeoJSON();
+    const olFeature = fmtGeoJSON.readFeature(geojson);
+
+    const loadFlags = {
+      callback1: false,
+      callback2: false,
+    };
+
+    const styleFunction1 = createOlStyleFunction(featureTypeStyle, {
+      imageLoadedCallback: () => {
+        loadFlags.callback1 = true;
+        if (loadFlags.callback2) {
+          done();
+        }
+      },
+    });
+
+    const styleFunction2 = createOlStyleFunction(featureTypeStyle, {
+      imageLoadedCallback: () => {
+        loadFlags.callback2 = true;
+        if (loadFlags.callback1) {
+          done();
+        }
+      },
+    });
+
+    // Evaluate both style functions with the same feature resulting in the same image style.
+    // Expected behaviour: each style evaluation gets its own callback called.
+    styleFunction1(olFeature, null);
+    styleFunction2(olFeature, null);
+  });
+
+  it('ImageLoadedCallback should be called for each style function created from different style objects containing the same image', done => {
+    const geojson = {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [175135, 441200],
+      },
+      properties: {
+        type: '2',
+      },
+    };
+
+    const fmtGeoJSON = new OLFormatGeoJSON();
+    const olFeature = fmtGeoJSON.readFeature(geojson);
+
+    const loadFlags = {
+      callback1: false,
+      callback2: false,
+    };
+
+    const styleFunction1 = createOlStyleFunction(featureTypeStyle, {
+      imageLoadedCallback: () => {
+        loadFlags.callback1 = true;
+        if (loadFlags.callback2) {
+          done();
+        }
+      },
+    });
+
+    const styleFunction2 = createOlStyleFunction(featureTypeStyle2, {
+      imageLoadedCallback: () => {
+        loadFlags.callback2 = true;
+        if (loadFlags.callback1) {
+          done();
+        }
+      },
+    });
+
+    // Evaluate both style functions with the same feature resulting in the same image style.
+    // Expected behaviour: each style evaluation gets its own callback called.
+    styleFunction1(olFeature, null);
+    styleFunction2(olFeature, null);
   });
 
   it('Can render both polygon stroke and externalgraphics', done => {

--- a/test/data/externalgraphic.sld.js
+++ b/test/data/externalgraphic.sld.js
@@ -86,6 +86,23 @@ export const externalGraphicSld = `<?xml version="1.0" encoding="UTF-8"?>
         </sld:Rule>
       </sld:FeatureTypeStyle>
     </UserStyle>
+    <UserStyle>
+      <sld:Name>icons_puntenlaag_2</sld:Name>
+      <sld:FeatureTypeStyle>
+        <sld:Rule>
+          <sld:Name>Always use the same image</sld:Name>
+          <sld:PointSymbolizer>
+            <sld:Graphic>
+              <sld:ExternalGraphic>
+                <sld:OnlineResource xlink:type="simple" xlink:href="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"/>
+                <sld:Format>image/png</sld:Format>
+              </sld:ExternalGraphic>
+              <sld:Size>24</sld:Size>
+            </sld:Graphic>
+          </sld:PointSymbolizer>
+        </sld:Rule>
+      </sld:FeatureTypeStyle>
+    </UserStyle>
   </NamedLayer>
 </sld:StyledLayerDescriptor>`;
 


### PR DESCRIPTION
This PR fixes the problem where the imageLoadedCallback of a style function did not get called if another style function already triggered a load for an ExternalGraphic image with the same image url.

Fixes #95 

