### PR TITLE
Implement anchor point for TextSymbolizer

### DIFF
--- a/docs/assets/sld-provincies.xml
+++ b/docs/assets/sld-provincies.xml
@@ -81,7 +81,7 @@
             <se:LabelPlacement>
               <se:PointPlacement>
                 <se:AnchorPoint>
-                  <se:AnchorPointX>0</se:AnchorPointX>
+                  <se:AnchorPointX>0.5</se:AnchorPointX>
                   <se:AnchorPointY>0.5</se:AnchorPointY>
                 </se:AnchorPoint>
               </se:PointPlacement>

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -2376,6 +2376,29 @@
     var offsetX = displacement.displacementx ? displacement.displacementx : 0;
     var offsetY = displacement.displacementy ? displacement.displacementy : 0;
 
+    // OpenLayers does not support fractional alignment, so snap the anchor to the most suitable option.
+    var anchorpoint = (pointplacement && pointplacement.anchorpoint) || {};
+
+    var textAlign = 'center';
+    var anchorpointx = Number(
+      anchorpoint.anchorpointx === '' ? NaN : anchorpoint.anchorpointx
+    );
+    if (anchorpointx < 0.25) {
+      textAlign = 'left';
+    } else if (anchorpointx > 0.75) {
+      textAlign = 'right';
+    }
+
+    var textBaseline = 'middle';
+    var anchorpointy = Number(
+      anchorpoint.anchorpointy === '' ? NaN : anchorpoint.anchorpointy
+    );
+    if (anchorpointy < 0.25) {
+      textBaseline = 'bottom';
+    } else if (anchorpointy > 0.75) {
+      textBaseline = 'top';
+    }
+
     // Assemble text style options.
     var textStyleOptions = {
       text: labelText,
@@ -2383,8 +2406,8 @@
       offsetX: Number(offsetX),
       offsetY: Number(offsetY),
       rotation: (Math.PI * labelRotationDegrees) / 180.0,
-      textAlign: 'center',
-      textBaseline: 'middle',
+      textAlign: textAlign,
+      textBaseline: textBaseline,
       fill: new style.Fill({
         color:
           fill.fillOpacity && fill.fill && fill.fill.slice(0, 1) === '#'

--- a/src/styles/textStyle.js
+++ b/src/styles/textStyle.js
@@ -58,6 +58,29 @@ function textStyle(textsymbolizer) {
   const offsetX = displacement.displacementx ? displacement.displacementx : 0;
   const offsetY = displacement.displacementy ? displacement.displacementy : 0;
 
+  // OpenLayers does not support fractional alignment, so snap the anchor to the most suitable option.
+  const anchorpoint = (pointplacement && pointplacement.anchorpoint) || {};
+
+  let textAlign = 'center';
+  const anchorpointx = Number(
+    anchorpoint.anchorpointx === '' ? NaN : anchorpoint.anchorpointx
+  );
+  if (anchorpointx < 0.25) {
+    textAlign = 'left';
+  } else if (anchorpointx > 0.75) {
+    textAlign = 'right';
+  }
+
+  let textBaseline = 'middle';
+  const anchorpointy = Number(
+    anchorpoint.anchorpointy === '' ? NaN : anchorpoint.anchorpointy
+  );
+  if (anchorpointy < 0.25) {
+    textBaseline = 'bottom';
+  } else if (anchorpointy > 0.75) {
+    textBaseline = 'top';
+  }
+
   // Assemble text style options.
   const textStyleOptions = {
     text: labelText,
@@ -65,8 +88,8 @@ function textStyle(textsymbolizer) {
     offsetX: Number(offsetX),
     offsetY: Number(offsetY),
     rotation: (Math.PI * labelRotationDegrees) / 180.0,
-    textAlign: 'center',
-    textBaseline: 'middle',
+    textAlign,
+    textBaseline,
     fill: new Fill({
       color:
         fill.fillOpacity && fill.fill && fill.fill.slice(0, 1) === '#'

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -605,6 +605,15 @@ describe('Text symbolizer', () => {
     expect(textStyle.getText().getText()).to.equal('TEST');
   });
 
+  it('Snaps text anchor point to the correct OpenLayers text alignment', () => {
+    const sldObject = Reader(textSymbolizerSld);
+    const [featureTypeStyle] = sldObject.layers[0].styles[0].featuretypestyles;
+    const styleFunction = createOlStyleFunction(featureTypeStyle);
+    const textStyle = styleFunction(pointFeature)[0];
+    expect(textStyle.getText().getTextAlign()).to.equal('left');
+    expect(textStyle.getText().getTextBaseline()).to.equal('top');
+  });
+
   it('Text symbolizer with dynamic label containing a number', () => {
     const sldObject = Reader(textSymbolizerDynamicSld);
     const [featureTypeStyle] = sldObject.layers[0].styles[0].featuretypestyles;

--- a/test/data/textSymbolizer.sld.js
+++ b/test/data/textSymbolizer.sld.js
@@ -12,6 +12,14 @@ export const textSymbolizerSld = `<?xml version="1.0" encoding="UTF-8"?>
         <Rule>
           <TextSymbolizer>
             <Label>TEST</Label>
+            <LabelPlacement>
+              <PointPlacement>
+                <AnchorPoint>
+                  <AnchorPointX>0</AnchorPointX>
+                  <AnchorPointY>1</AnchorPointY>
+                </AnchorPoint>
+              </PointPlacement>
+            </LabelPlacement>
           </TextSymbolizer>
         </Rule>
       </FeatureTypeStyle>


### PR DESCRIPTION
Implement AnchorpointX/Y label placement for text.
Note that this is only an approximation, because OpenLayers only supports left/right/top/bottom/center text aligment.

Implements #99 