### PR TITLE
Point symbolizer for line polygon

### DIFF
--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -2496,9 +2496,8 @@
 
   /**
    * Get the point located at the middle along a line string.
-   * In case of a multilinestring, a multipoint geometry is returned, one midpoint for each segment.
    * @param {OLGeometry} geometry An OpenLayers geometry. Must be LineString or MultiLineString.
-   * @returns {OLGeometry} an OpenLayers Point or MultiPoint geometry.
+   * @returns {Array<number>} An [x, y] coordinate array.
    */
   function getLineMidpoint(geometry) {
     // Use the splitpoints routine to distribute points over the line with
@@ -2511,7 +2510,7 @@
     var ref = splitPoints[1];
     var x = ref[0];
     var y = ref[1];
-    return new geom.Point([x, y]);
+    return [x, y];
   }
 
   /**
@@ -2523,16 +2522,21 @@
    * @returns {ol/Style} OpenLayers style instance.
    */
   function getLinePointStyle(symbolizer, feature) {
-    var geom = feature.getGeometry();
-    if (!geom) {
+    var geom$1 = feature.getGeometry();
+    if (!geom$1) {
       return null;
     }
 
     var pointStyle = null;
-    var geomType = geom.getType();
+    var geomType = geom$1.getType();
     if (geomType === 'LineString') {
       pointStyle = getPointStyle(symbolizer, feature);
-      pointStyle.setGeometry(getLineMidpoint(geom));
+      pointStyle.setGeometry(new geom.Point(getLineMidpoint(geom$1)));
+    } else if (geomType === 'MultiLineString') {
+      var lineStrings = geom$1.getLineStrings();
+      var multiPointCoords = lineStrings.map(getLineMidpoint);
+      pointStyle = getPointStyle(symbolizer, feature);
+      pointStyle.setGeometry(new geom.MultiPoint(multiPointCoords));
     }
 
     return pointStyle;

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -7,6 +7,7 @@ import getLineStyle from './styles/lineStyle';
 import getPolygonStyle from './styles/polygonStyle';
 import getTextStyle from './styles/textStyle';
 import getLinePointStyle from './styles/linePointStyle';
+import getPolygonPointStyle from './styles/polygonPointStyle';
 
 const defaultStyles = [defaultPointStyle];
 
@@ -72,14 +73,17 @@ export default function OlStyler(GeometryStyles, feature) {
 
     case 'Polygon':
     case 'MultiPolygon':
-      for (let i = 0; i < polygon.length; i += 1) {
-        appendStyle(styles, polygon[i], feature, getPolygonStyle);
+      for (let j = 0; j < polygon.length; j += 1) {
+        appendStyle(styles, polygon[j], feature, getPolygonStyle);
       }
       for (let j = 0; j < line.length; j += 1) {
         appendStyle(styles, line[j], feature, getLineStyle);
       }
-      for (let k = 0; k < text.length; k += 1) {
-        styles.push(getTextStyle(text[k], feature));
+      for (let j = 0; j < point.length; j += 1) {
+        appendStyle(styles, point[j], feature, getPolygonPointStyle);
+      }
+      for (let j = 0; j < text.length; j += 1) {
+        styles.push(getTextStyle(text[j], feature));
       }
       break;
 

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -6,6 +6,7 @@ import getPointStyle from './styles/pointStyle';
 import getLineStyle from './styles/lineStyle';
 import getPolygonStyle from './styles/polygonStyle';
 import getTextStyle from './styles/textStyle';
+import getLinePointStyle from './styles/linePointStyle';
 
 const defaultStyles = [defaultPointStyle];
 
@@ -60,6 +61,9 @@ export default function OlStyler(GeometryStyles, feature) {
     case 'MultiLineString':
       for (let j = 0; j < line.length; j += 1) {
         appendStyle(styles, line[j], feature, getLineStyle);
+      }
+      for (let j = 0; j < point.length; j += 1) {
+        appendStyle(styles, point[j], feature, getLinePointStyle);
       }
       for (let j = 0; j < text.length; j += 1) {
         styles.push(getTextStyle(text[j], feature));

--- a/src/styles/geometryCalcs.js
+++ b/src/styles/geometryCalcs.js
@@ -1,0 +1,101 @@
+import { containsCoordinate } from 'ol/extent';
+
+// eslint-disable-next-line import/prefer-default-export
+export function splitLineString(geometry, graphicSpacing, options) {
+  function calculatePointsDistance(coord1, coord2) {
+    const dx = coord1[0] - coord2[0];
+    const dy = coord1[1] - coord2[1];
+    return Math.sqrt(dx * dx + dy * dy);
+  }
+
+  function calculateSplitPointCoords(
+    startNode,
+    nextNode,
+    distanceBetweenNodes,
+    distanceToSplitPoint
+  ) {
+    const d = distanceToSplitPoint / distanceBetweenNodes;
+    const x = nextNode[0] + (startNode[0] - nextNode[0]) * d;
+    const y = nextNode[1] + (startNode[1] - nextNode[1]) * d;
+    return [x, y];
+  }
+
+  function calculateAngle(startNode, nextNode, alwaysUp) {
+    const x = startNode[0] - nextNode[0];
+    const y = startNode[1] - nextNode[1];
+    let angle = Math.atan(x / y);
+    if (!alwaysUp) {
+      if (y > 0) {
+        angle += Math.PI;
+      } else if (x < 0) {
+        angle += Math.PI * 2;
+      }
+      // angle = y > 0 ? angle + Math.PI : x < 0 ? angle + Math.PI * 2 : angle;
+    }
+    return angle;
+  }
+
+  const splitPoints = [];
+  const coords = geometry.getCoordinates();
+
+  let coordIndex = 0;
+  let startPoint = coords[coordIndex];
+  let nextPoint = coords[coordIndex + 1];
+  let angle = calculateAngle(startPoint, nextPoint, options.alwaysUp);
+
+  const n = Math.ceil(geometry.getLength() / graphicSpacing);
+  const segmentLength = geometry.getLength() / n;
+  let currentSegmentLength = options.midPoints
+    ? segmentLength / 2
+    : segmentLength;
+
+  for (let i = 0; i <= n; i += 1) {
+    const distanceBetweenPoints = calculatePointsDistance(
+      startPoint,
+      nextPoint
+    );
+    currentSegmentLength += distanceBetweenPoints;
+
+    if (currentSegmentLength < segmentLength) {
+      coordIndex += 1;
+      if (coordIndex < coords.length - 1) {
+        startPoint = coords[coordIndex];
+        nextPoint = coords[coordIndex + 1];
+        angle = calculateAngle(startPoint, nextPoint, options.alwaysUp);
+        i -= 1;
+        // continue;
+      } else {
+        if (!options.midPoints) {
+          const splitPointCoords = nextPoint;
+          if (
+            !options.extent ||
+            containsCoordinate(options.extent, splitPointCoords)
+          ) {
+            splitPointCoords.push(angle);
+            splitPoints.push(splitPointCoords);
+          }
+        }
+        break;
+      }
+    } else {
+      const distanceToSplitPoint = currentSegmentLength - segmentLength;
+      const splitPointCoords = calculateSplitPointCoords(
+        startPoint,
+        nextPoint,
+        distanceBetweenPoints,
+        distanceToSplitPoint
+      );
+      startPoint = splitPointCoords.slice();
+      if (
+        !options.extent ||
+        containsCoordinate(options.extent, splitPointCoords)
+      ) {
+        splitPointCoords.push(angle);
+        splitPoints.push(splitPointCoords);
+      }
+      currentSegmentLength = 0;
+    }
+  }
+
+  return splitPoints;
+}

--- a/src/styles/graphicStrokeStyle.js
+++ b/src/styles/graphicStrokeStyle.js
@@ -1,111 +1,12 @@
 import { Style } from 'ol/style';
 import { toContext } from 'ol/render';
 import { Point, LineString } from 'ol/geom';
-import { containsCoordinate } from 'ol/extent';
 
 import { DEFAULT_MARK_SIZE, DEFAULT_EXTERNALGRAPHIC_SIZE } from '../constants';
 import evaluate from '../olEvaluator';
 import getPointStyle from './pointStyle';
 import { calculateGraphicSpacing } from './styleUtils';
-
-function splitLineString(geometry, graphicSpacing, options) {
-  function calculatePointsDistance(coord1, coord2) {
-    const dx = coord1[0] - coord2[0];
-    const dy = coord1[1] - coord2[1];
-    return Math.sqrt(dx * dx + dy * dy);
-  }
-
-  function calculateSplitPointCoords(
-    startNode,
-    nextNode,
-    distanceBetweenNodes,
-    distanceToSplitPoint
-  ) {
-    const d = distanceToSplitPoint / distanceBetweenNodes;
-    const x = nextNode[0] + (startNode[0] - nextNode[0]) * d;
-    const y = nextNode[1] + (startNode[1] - nextNode[1]) * d;
-    return [x, y];
-  }
-
-  function calculateAngle(startNode, nextNode, alwaysUp) {
-    const x = startNode[0] - nextNode[0];
-    const y = startNode[1] - nextNode[1];
-    let angle = Math.atan(x / y);
-    if (!alwaysUp) {
-      if (y > 0) {
-        angle += Math.PI;
-      } else if (x < 0) {
-        angle += Math.PI * 2;
-      }
-      // angle = y > 0 ? angle + Math.PI : x < 0 ? angle + Math.PI * 2 : angle;
-    }
-    return angle;
-  }
-
-  const splitPoints = [];
-  const coords = geometry.getCoordinates();
-
-  let coordIndex = 0;
-  let startPoint = coords[coordIndex];
-  let nextPoint = coords[coordIndex + 1];
-  let angle = calculateAngle(startPoint, nextPoint, options.alwaysUp);
-
-  const n = Math.ceil(geometry.getLength() / graphicSpacing);
-  const segmentLength = geometry.getLength() / n;
-  let currentSegmentLength = options.midPoints
-    ? segmentLength / 2
-    : segmentLength;
-
-  for (let i = 0; i <= n; i += 1) {
-    const distanceBetweenPoints = calculatePointsDistance(
-      startPoint,
-      nextPoint
-    );
-    currentSegmentLength += distanceBetweenPoints;
-
-    if (currentSegmentLength < segmentLength) {
-      coordIndex += 1;
-      if (coordIndex < coords.length - 1) {
-        startPoint = coords[coordIndex];
-        nextPoint = coords[coordIndex + 1];
-        angle = calculateAngle(startPoint, nextPoint, options.alwaysUp);
-        i -= 1;
-        // continue;
-      } else {
-        if (!options.midPoints) {
-          const splitPointCoords = nextPoint;
-          if (
-            !options.extent ||
-            containsCoordinate(options.extent, splitPointCoords)
-          ) {
-            splitPointCoords.push(angle);
-            splitPoints.push(splitPointCoords);
-          }
-        }
-        break;
-      }
-    } else {
-      const distanceToSplitPoint = currentSegmentLength - segmentLength;
-      const splitPointCoords = calculateSplitPointCoords(
-        startPoint,
-        nextPoint,
-        distanceBetweenPoints,
-        distanceToSplitPoint
-      );
-      startPoint = splitPointCoords.slice();
-      if (
-        !options.extent ||
-        containsCoordinate(options.extent, splitPointCoords)
-      ) {
-        splitPointCoords.push(angle);
-        splitPoints.push(splitPointCoords);
-      }
-      currentSegmentLength = 0;
-    }
-  }
-
-  return splitPoints;
-}
+import { splitLineString } from './geometryCalcs';
 
 // A flag to prevent multiple renderer patches.
 let rendererPatched = false;

--- a/src/styles/linePointStyle.js
+++ b/src/styles/linePointStyle.js
@@ -1,0 +1,48 @@
+import { Point } from 'ol/geom';
+
+import getPointStyle from './pointStyle';
+import { splitLineString } from './geometryCalcs';
+
+/**
+ * Get the point located at the middle along a line string.
+ * In case of a multilinestring, a multipoint geometry is returned, one midpoint for each segment.
+ * @param {OLGeometry} geometry An OpenLayers geometry. Must be LineString or MultiLineString.
+ * @returns {OLGeometry} an OpenLayers Point or MultiPoint geometry.
+ */
+function getLineMidpoint(geometry) {
+  // Use the splitpoints routine to distribute points over the line with
+  // a point-to-point distance along the line equal to half line length.
+  // This results in three points. Take the middle point.
+  const splitPoints = splitLineString(geometry, geometry.getLength() / 2, {
+    alwaysUp: true,
+    midPoints: false,
+  });
+  const [x, y] = splitPoints[1];
+  return new Point([x, y]);
+}
+
+/**
+ * @private
+ * Get an OL point style instance for a line feature according to a symbolizer.
+ * The style will render a point on the middle of the line.
+ * @param {object} symbolizer SLD symbolizer object.
+ * @param {ol/Feature} feature OpenLayers Feature.
+ * @returns {ol/Style} OpenLayers style instance.
+ */
+function getLinePointStyle(symbolizer, feature) {
+  const geom = feature.getGeometry();
+  if (!geom) {
+    return null;
+  }
+
+  let pointStyle = null;
+  const geomType = geom.getType();
+  if (geomType === 'LineString') {
+    pointStyle = getPointStyle(symbolizer, feature);
+    pointStyle.setGeometry(getLineMidpoint(geom));
+  }
+
+  return pointStyle;
+}
+
+export default getLinePointStyle;

--- a/src/styles/linePointStyle.js
+++ b/src/styles/linePointStyle.js
@@ -5,7 +5,7 @@ import { splitLineString } from './geometryCalcs';
 
 /**
  * Get the point located at the middle along a line string.
- * @param {OLGeometry} geometry An OpenLayers geometry. Must be LineString or MultiLineString.
+ * @param {ol/geom/LineString} geometry An OpenLayers LineString geometry.
  * @returns {Array<number>} An [x, y] coordinate array.
  */
 function getLineMidpoint(geometry) {

--- a/src/styles/linePointStyle.js
+++ b/src/styles/linePointStyle.js
@@ -1,13 +1,12 @@
-import { Point } from 'ol/geom';
+import { MultiPoint, Point } from 'ol/geom';
 
 import getPointStyle from './pointStyle';
 import { splitLineString } from './geometryCalcs';
 
 /**
  * Get the point located at the middle along a line string.
- * In case of a multilinestring, a multipoint geometry is returned, one midpoint for each segment.
  * @param {OLGeometry} geometry An OpenLayers geometry. Must be LineString or MultiLineString.
- * @returns {OLGeometry} an OpenLayers Point or MultiPoint geometry.
+ * @returns {Array<number>} An [x, y] coordinate array.
  */
 function getLineMidpoint(geometry) {
   // Use the splitpoints routine to distribute points over the line with
@@ -18,7 +17,7 @@ function getLineMidpoint(geometry) {
     midPoints: false,
   });
   const [x, y] = splitPoints[1];
-  return new Point([x, y]);
+  return [x, y];
 }
 
 /**
@@ -39,7 +38,12 @@ function getLinePointStyle(symbolizer, feature) {
   const geomType = geom.getType();
   if (geomType === 'LineString') {
     pointStyle = getPointStyle(symbolizer, feature);
-    pointStyle.setGeometry(getLineMidpoint(geom));
+    pointStyle.setGeometry(new Point(getLineMidpoint(geom)));
+  } else if (geomType === 'MultiLineString') {
+    const lineStrings = geom.getLineStrings();
+    const multiPointCoords = lineStrings.map(getLineMidpoint);
+    pointStyle = getPointStyle(symbolizer, feature);
+    pointStyle.setGeometry(new MultiPoint(multiPointCoords));
   }
 
   return pointStyle;

--- a/src/styles/polygonPointStyle.js
+++ b/src/styles/polygonPointStyle.js
@@ -1,0 +1,45 @@
+import { MultiPoint, Point } from 'ol/geom';
+
+import getPointStyle from './pointStyle';
+
+/**
+ * Get the point located at the centroid of a polygon.
+ * @param {ol/geom/Polygon} geometry An OpenLayers Polygon geometry.
+ * @returns {Array<number>} An [x, y] coordinate array.
+ */
+function getInteriorPoint(geometry) {
+  // Use OpenLayers getInteriorPoint method to get a 'good' interior point.
+  const [x, y] = geometry.getInteriorPoint().getCoordinates();
+  return [x, y];
+}
+
+/**
+ * @private
+ * Get an OL point style instance for a line feature according to a symbolizer.
+ * The style will render a point on the middle of the line.
+ * @param {object} symbolizer SLD symbolizer object.
+ * @param {ol/Feature} feature OpenLayers Feature.
+ * @returns {ol/Style} OpenLayers style instance.
+ */
+function getPolygonPointStyle(symbolizer, feature) {
+  const geom = feature.getGeometry();
+  if (!geom) {
+    return null;
+  }
+
+  let pointStyle = null;
+  const geomType = geom.getType();
+  if (geomType === 'Polygon') {
+    pointStyle = getPointStyle(symbolizer, feature);
+    pointStyle.setGeometry(new Point(getInteriorPoint(geom)));
+  } else if (geomType === 'MultiPolygon') {
+    const polygons = geom.getPolygons();
+    const multiPointCoords = polygons.map(getInteriorPoint);
+    pointStyle = getPointStyle(symbolizer, feature);
+    pointStyle.setGeometry(new MultiPoint(multiPointCoords));
+  }
+
+  return pointStyle;
+}
+
+export default getPolygonPointStyle;

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -688,7 +688,7 @@ describe('PointSymbolizer inside line or polygon', () => {
     };
     const feature = fmtGeoJSON.readFeature(lineGeoJSON);
     const style = styleFunction(feature)[0];
-    // Style should have a custom geometry: the line's mid-point.
+    // Style should have a custom geometry: the line midpoint.
     const midPoint = style.getGeometry();
     expect(midPoint.getType()).to.equal('Point');
     expect(midPoint.getCoordinates()).to.deep.equal([1, 0.5]);
@@ -706,13 +706,57 @@ describe('PointSymbolizer inside line or polygon', () => {
     };
     const feature = fmtGeoJSON.readFeature(lineGeoJSON);
     const style = styleFunction(feature)[0];
-    // Style should have a custom geometry: the line's mid-point.
+    // Style should have a custom geometry: a multipoint of segment midpoints.
     const midPoint = style.getGeometry();
     expect(midPoint.getType()).to.equal('MultiPoint');
     expect(midPoint.getCoordinates()).to.deep.equal([
       [0.5, 0],
       [1.5, 1],
       [2.5, 2],
+    ]);
+  });
+
+  it('Places point in the centroid of a Polygon', () => {
+    const lineGeoJSON = {
+      type: 'Feature',
+      geometry: {
+        type: 'Polygon',
+        // prettier-ignore
+        coordinates: [[[0, 0], [1, 0], [1, 1], [0.5, 1.5], [0, 1], [0, 0]]],
+      },
+      properties: {},
+    };
+    const feature = fmtGeoJSON.readFeature(lineGeoJSON);
+    const style = styleFunction(feature)[0];
+    // Style should have a custom geometry: the polygon mid-point.
+    const midPoint = style.getGeometry();
+    expect(midPoint.getType()).to.equal('Point');
+    expect(midPoint.getCoordinates()).to.deep.equal([0.5, 0.75]);
+  });
+
+  it('Calculates centroids for each MultiPolygon part', () => {
+    const lineGeoJSON = {
+      type: 'Feature',
+      geometry: {
+        type: 'MultiPolygon',
+        // prettier-ignore
+        coordinates: [
+          [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+          [[[1, 1], [2, 1], [2, 2], [1, 2], [1, 1]]],
+          [[[2, 2], [3, 2], [3, 3], [2, 3], [2, 2]]],
+        ],
+      },
+      properties: {},
+    };
+    const feature = fmtGeoJSON.readFeature(lineGeoJSON);
+    const style = styleFunction(feature)[0];
+    // Style should have a custom geometry: a MultiPoint of one centroid per MultiPolygon part.
+    const midPoint = style.getGeometry();
+    expect(midPoint.getType()).to.equal('MultiPoint');
+    expect(midPoint.getCoordinates()).to.deep.equal([
+      [0.5, 0.5],
+      [1.5, 1.5],
+      [2.5, 2.5],
     ]);
   });
 });

--- a/test/data/simple-point-symbolizer.sld.js
+++ b/test/data/simple-point-symbolizer.sld.js
@@ -1,0 +1,36 @@
+export const simplePointSymbolizerSld = `<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" 
+  xmlns:ogc="http://www.opengis.net/ogc" 
+  xmlns:xlink="http://www.w3.org/1999/xlink" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>Simple point</Name>
+    <UserStyle>
+      <Name>Simple point</Name>
+      <FeatureTypeStyle>
+        <Rule>
+          <PointSymbolizer>
+            <Graphic>
+              <Mark>
+                <WellKnownName>square</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#FF0000</CssParameter>
+                  <CssParameter name="fill-opacity">1</CssParameter>
+                </Fill>
+                <Stroke>
+                  <CssParameter name="stroke">#000000</CssParameter>
+                  <CssParameter name="stroke-width">1</CssParameter>
+                  <CssParameter name="stroke-opacity">1</CssParameter>
+                </Stroke>
+              </Mark>
+              <Size>4</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>
+`;
+
+export default simplePointSymbolizerSld;


### PR DESCRIPTION
Fixes #101 

This PR fixes the case where a PointSymbolizer is ignored when used on a (Multi)Line/Polygon geometry.
According to the SLD spec:

> In this case, if a line, polygon, 
or raster geometry is used with this Symbolizer, then the semantic is to use the centroid 
of the geometry, or any similar representative point.

I have interpreted 'representative point' as follows:
* For a LineString, the point is placed in the middle of the line string.
* For a MultiLineString, a point is placed in the middle of each segment.
* For a Polygon, the point is placed using OpenLayers `getInteriorPoint` method which is the same point used for text label placement.
* For a MultiPolygon, a point is placed on each part separately.