### PR TITLE
Fix comparisons

### DIFF
--- a/src/Filter.js
+++ b/src/Filter.js
@@ -28,6 +28,16 @@ function propertyIsEqualTo(comparison, value) {
   return value == comparison.literal;
 }
 
+// Watch out! Null-ish values should not pass propertyIsNotEqualTo,
+// just like in databases.
+// This means that PropertyIsNotEqualTo is not the same as NOT(PropertyIsEqualTo).
+function propertyIsNotEqualTo(comparison, value) {
+  if (propertyIsNull(comparison, value)) {
+    return false;
+  }
+  return !propertyIsEqualTo(comparison, value);
+}
+
 function propertyIsNull(comparison, value) {
   /* eslint-disable-next-line eqeqeq */
   return value == null;
@@ -98,7 +108,7 @@ function doComparison(comparison, feature, getProperty) {
         propertyIsLessThan(comparison, value)
       );
     case 'propertyisnotequalto':
-      return !propertyIsEqualTo(comparison, value);
+      return propertyIsNotEqualTo(comparison, value);
     case 'propertyisgreaterthan':
       return propertyIsGreaterThan(comparison, value);
     case 'propertyisgreaterthanorequalto':

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -34,6 +34,7 @@ function compare(a, b, matchcase) {
   if (!(Number.isNaN(aNumber) || Number.isNaN(bNumber))) {
     return compareNumbers(aNumber, bNumber);
   }
+
   if (matchcase) {
     return caseSensitiveCollator.compare(a, b);
   }
@@ -45,11 +46,19 @@ function propertyIsLessThan(comparison, value) {
     return false;
   }
 
+  if (isNullOrUndefined(comparison.literal)) {
+    return false;
+  }
+
   return compare(value, comparison.literal) < 0;
 }
 
 function propertyIsGreaterThan(comparison, value) {
   if (isNullOrUndefined(value)) {
+    return false;
+  }
+
+  if (isNullOrUndefined(comparison.literal)) {
     return false;
   }
 
@@ -61,18 +70,27 @@ function propertyIsBetween(comparison, value) {
     return false;
   }
 
-  // Todo: support string comparison as well
   const lowerBoundary = comparison.lowerboundary;
+  if (isNullOrUndefined(lowerBoundary)) {
+    return false;
+  }
+
   const upperBoundary = comparison.upperboundary;
-  const numericValue = value;
+  if (isNullOrUndefined(upperBoundary)) {
+    return false;
+  }
+
   return (
-    compare(lowerBoundary, numericValue) <= 0 &&
-    compare(upperBoundary, numericValue) >= 0
+    compare(lowerBoundary, value) <= 0 && compare(upperBoundary, value) >= 0
   );
 }
 
 function propertyIsEqualTo(comparison, value) {
   if (isNullOrUndefined(value)) {
+    return false;
+  }
+
+  if (isNullOrUndefined(comparison.literal)) {
     return false;
   }
 

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -30,14 +30,17 @@ function compare(a, b, matchcase) {
   // If a and/or b is non-numeric, compare both values as strings.
   const aString = a.toString();
   const bString = b.toString();
-  return aString.localeCompare(bString, undefined, {
-    sensitivity: matchcase ? 'case' : 'base',
-  });
 
-  // if (matchcase) {
-  //   return caseSensitiveCollator.compare(a, b);
-  // }
-  // return caseInsensitiveCollator.compare(a, b);
+  // Note: using locale compare with sensitivity option fails the CI test, while it works on my PC.
+  // So, case insensitive comparison is done in a more brute-force way by using lower case comparison.
+  // Original method:
+  // const caseSensitiveCollator = new Intl.Collator(undefined, { sensitivity: 'case' });
+  // caseSensitiveCollator.compare(string1, string2);
+  if (matchcase) {
+    return aString.localeCompare(bString);
+  }
+
+  return aString.toLowerCase().localeCompare(bString.toLowerCase());
 }
 
 function propertyIsLessThan(comparison, value) {

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -1,39 +1,67 @@
+function isNullish(value) {
+  /* eslint-disable-next-line eqeqeq */
+  return value == null;
+}
+
+function compareNumbers(a, b) {
+  if (a < b) {
+    return -1;
+  }
+  if (a === b) {
+    return 0;
+  }
+  return 1;
+}
+
+function toNumber(text) {
+  if (text === '') {
+    return NaN;
+  }
+  return Number(text);
+}
+
+function compare(a, b) {
+  const aNumber = toNumber(a);
+  const bNumber = toNumber(b);
+  if (!(Number.isNaN(aNumber) || Number.isNaN(bNumber))) {
+    return compareNumbers(aNumber, bNumber);
+  }
+  throw new Error('TODO: implement string comparison between ' + a + ' and ' + b);
+}
+
 function propertyIsLessThan(comparison, value) {
-  if (propertyIsNull(comparison, value)) {
+  if (isNullish(value)) {
     return false;
   }
 
-  return (
-    // Todo: support string comparison as well
-    typeof value !== 'undefined' && Number(value) < Number(comparison.literal)
-  );
+  return compare(value, comparison.literal) < 0;
 }
 
 function propertyIsGreaterThan(comparison, value) {
-  if (propertyIsNull(comparison, value)) {
+  if (isNullish(value)) {
     return false;
   }
 
-  return (
-    // Todo: support string comparison as well
-    typeof value !== 'undefined' && Number(value) > Number(comparison.literal)
-  );
+  return compare(value, comparison.literal) > 0;
 }
 
 function propertyIsBetween(comparison, value) {
-  if (propertyIsNull(comparison, value)) {
+  if (isNullish(value)) {
     return false;
   }
 
   // Todo: support string comparison as well
-  const lowerBoundary = Number(comparison.lowerboundary);
-  const upperBoundary = Number(comparison.upperboundary);
-  const numericValue = Number(value);
-  return numericValue >= lowerBoundary && numericValue <= upperBoundary;
+  const lowerBoundary = comparison.lowerboundary;
+  const upperBoundary = comparison.upperboundary;
+  const numericValue = value;
+  return (
+    compare(lowerBoundary, numericValue) <= 0 &&
+    compare(upperBoundary, numericValue) >= 0
+  );
 }
 
 function propertyIsEqualTo(comparison, value) {
-  if (propertyIsNull(comparison, value)) {
+  if (isNullish(value)) {
     return false;
   }
 
@@ -45,16 +73,11 @@ function propertyIsEqualTo(comparison, value) {
 // just like in databases.
 // This means that PropertyIsNotEqualTo is not the same as NOT(PropertyIsEqualTo).
 function propertyIsNotEqualTo(comparison, value) {
-  if (propertyIsNull(comparison, value)) {
+  if (isNullish(value)) {
     return false;
   }
 
   return !propertyIsEqualTo(comparison, value);
-}
-
-function propertyIsNull(comparison, value) {
-  /* eslint-disable-next-line eqeqeq */
-  return value == null;
 }
 
 /**
@@ -68,7 +91,7 @@ function propertyIsNull(comparison, value) {
 function propertyIsLike(comparison, value) {
   const pattern = comparison.literal;
 
-  if (propertyIsNull(comparison, value)) {
+  if (isNullish(value)) {
     return false;
   }
 
@@ -95,9 +118,10 @@ function propertyIsLike(comparison, value) {
   // Bookend the regular expression.
   patternAsRegex = `^${patternAsRegex}$`;
 
-  const rex = matchcase === false
-    ? new RegExp(patternAsRegex, 'i')
-    : new RegExp(patternAsRegex);
+  const rex =
+    matchcase === false
+      ? new RegExp(patternAsRegex, 'i')
+      : new RegExp(patternAsRegex);
   return rex.test(value);
 }
 
@@ -135,7 +159,7 @@ function doComparison(comparison, feature, getProperty) {
     case 'propertyisbetween':
       return propertyIsBetween(comparison, value);
     case 'propertyisnull':
-      return propertyIsNull(comparison, value);
+      return isNullish(value);
     case 'propertyislike':
       return propertyIsLike(comparison, value);
     default:

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -5,6 +5,13 @@ function propertyIsLessThan(comparison, value) {
   );
 }
 
+function propertyIsGreaterThan(comparison, value) {
+  return (
+    // Todo: support string comparison as well
+    typeof value !== 'undefined' && Number(value) > Number(comparison.literal)
+  );
+}
+
 function propertyIsBetween(comparison, value) {
   // Todo: support string comparison as well
   const lowerBoundary = Number(comparison.lowerboundary);
@@ -93,12 +100,12 @@ function doComparison(comparison, feature, getProperty) {
     case 'propertyisnotequalto':
       return !propertyIsEqualTo(comparison, value);
     case 'propertyisgreaterthan':
-      return (
-        !propertyIsLessThan(comparison, value) &&
-        !propertyIsEqualTo(comparison, value)
-      );
+      return propertyIsGreaterThan(comparison, value);
     case 'propertyisgreaterthanorequalto':
-      return !propertyIsLessThan(comparison, value);
+      return (
+        propertyIsEqualTo(comparison, value) ||
+        propertyIsGreaterThan(comparison, value)
+      );
     case 'propertyisbetween':
       return propertyIsBetween(comparison, value);
     case 'propertyisnull':

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -1,11 +1,3 @@
-const caseInsensitiveCollator = new Intl.Collator(undefined, {
-  sensitivity: 'base',
-});
-
-const caseSensitiveCollator = new Intl.Collator(undefined, {
-  sensitivity: 'case',
-});
-
 function isNullOrUndefined(value) {
   /* eslint-disable-next-line eqeqeq */
   return value == null;

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -1,4 +1,12 @@
-function isNullish(value) {
+const caseInsensitiveCompare = new Intl.Collator(undefined, {
+  sensitivity: 'base',
+}).compare;
+
+const caseSensitiveCompare = new Intl.Collator(undefined, {
+  sensitivity: 'case',
+}).compare;
+
+function isNullOrUndefined(value) {
   /* eslint-disable-next-line eqeqeq */
   return value == null;
 }
@@ -20,17 +28,20 @@ function toNumber(text) {
   return Number(text);
 }
 
-function compare(a, b) {
+function compare(a, b, matchcase) {
   const aNumber = toNumber(a);
   const bNumber = toNumber(b);
   if (!(Number.isNaN(aNumber) || Number.isNaN(bNumber))) {
     return compareNumbers(aNumber, bNumber);
   }
-  throw new Error('TODO: implement string comparison between ' + a + ' and ' + b);
+  if (matchcase) {
+    return caseSensitiveCompare(a, b);
+  }
+  return caseInsensitiveCompare(a, b);
 }
 
 function propertyIsLessThan(comparison, value) {
-  if (isNullish(value)) {
+  if (isNullOrUndefined(value)) {
     return false;
   }
 
@@ -38,7 +49,7 @@ function propertyIsLessThan(comparison, value) {
 }
 
 function propertyIsGreaterThan(comparison, value) {
-  if (isNullish(value)) {
+  if (isNullOrUndefined(value)) {
     return false;
   }
 
@@ -46,7 +57,7 @@ function propertyIsGreaterThan(comparison, value) {
 }
 
 function propertyIsBetween(comparison, value) {
-  if (isNullish(value)) {
+  if (isNullOrUndefined(value)) {
     return false;
   }
 
@@ -61,8 +72,12 @@ function propertyIsBetween(comparison, value) {
 }
 
 function propertyIsEqualTo(comparison, value) {
-  if (isNullish(value)) {
+  if (isNullOrUndefined(value)) {
     return false;
+  }
+
+  if (!comparison.matchcase) {
+    return compare(comparison.literal, value, false) === 0;
   }
 
   /* eslint-disable-next-line eqeqeq */
@@ -73,7 +88,7 @@ function propertyIsEqualTo(comparison, value) {
 // just like in databases.
 // This means that PropertyIsNotEqualTo is not the same as NOT(PropertyIsEqualTo).
 function propertyIsNotEqualTo(comparison, value) {
-  if (isNullish(value)) {
+  if (isNullOrUndefined(value)) {
     return false;
   }
 
@@ -91,7 +106,7 @@ function propertyIsNotEqualTo(comparison, value) {
 function propertyIsLike(comparison, value) {
   const pattern = comparison.literal;
 
-  if (isNullish(value)) {
+  if (isNullOrUndefined(value)) {
     return false;
   }
 
@@ -159,7 +174,7 @@ function doComparison(comparison, feature, getProperty) {
     case 'propertyisbetween':
       return propertyIsBetween(comparison, value);
     case 'propertyisnull':
-      return isNullish(value);
+      return isNullOrUndefined(value);
     case 'propertyislike':
       return propertyIsLike(comparison, value);
     default:

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -1,10 +1,10 @@
-const caseInsensitiveCompare = new Intl.Collator(undefined, {
+const caseInsensitiveCollator = new Intl.Collator(undefined, {
   sensitivity: 'base',
-}).compare;
+});
 
-const caseSensitiveCompare = new Intl.Collator(undefined, {
+const caseSensitiveCollator = new Intl.Collator(undefined, {
   sensitivity: 'case',
-}).compare;
+});
 
 function isNullOrUndefined(value) {
   /* eslint-disable-next-line eqeqeq */
@@ -35,9 +35,9 @@ function compare(a, b, matchcase) {
     return compareNumbers(aNumber, bNumber);
   }
   if (matchcase) {
-    return caseSensitiveCompare(a, b);
+    return caseSensitiveCollator.compare(a, b);
   }
-  return caseInsensitiveCompare(a, b);
+  return caseInsensitiveCollator.compare(a, b);
 }
 
 function propertyIsLessThan(comparison, value) {

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -35,10 +35,17 @@ function compare(a, b, matchcase) {
     return compareNumbers(aNumber, bNumber);
   }
 
-  if (matchcase) {
-    return caseSensitiveCollator.compare(a, b);
-  }
-  return caseInsensitiveCollator.compare(a, b);
+  // If a and/or b is non-numeric, compare both values as strings.
+  const aString = a.toString();
+  const bString = b.toString();
+  return aString.localeCompare(bString, undefined, {
+    sensitivity: matchcase ? 'case' : 'base',
+  });
+
+  // if (matchcase) {
+  //   return caseSensitiveCollator.compare(a, b);
+  // }
+  // return caseInsensitiveCollator.compare(a, b);
 }
 
 function propertyIsLessThan(comparison, value) {

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -98,10 +98,7 @@ function doComparison(comparison, feature, getProperty) {
         !propertyIsEqualTo(comparison, value)
       );
     case 'propertyisgreaterthanorequalto':
-      return (
-        !propertyIsLessThan(comparison, value) ||
-        propertyIsEqualTo(comparison, value)
-      );
+      return !propertyIsLessThan(comparison, value);
     case 'propertyisbetween':
       return propertyIsBetween(comparison, value);
     case 'propertyisnull':

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -73,7 +73,7 @@ function propertyIsLike(comparison, value) {
   }
 
   // Create regex string from match pattern.
-  const { wildcard, singlechar, escapechar } = comparison;
+  const { wildcard, singlechar, escapechar, matchcase } = comparison;
 
   // Replace wildcard by '.*'
   let patternAsRegex = pattern.replace(new RegExp(`[${wildcard}]`, 'g'), '.*');
@@ -95,7 +95,9 @@ function propertyIsLike(comparison, value) {
   // Bookend the regular expression.
   patternAsRegex = `^${patternAsRegex}$`;
 
-  const rex = new RegExp(patternAsRegex);
+  const rex = matchcase === false
+    ? new RegExp(patternAsRegex, 'i')
+    : new RegExp(patternAsRegex);
   return rex.test(value);
 }
 

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -1,4 +1,8 @@
 function propertyIsLessThan(comparison, value) {
+  if (propertyIsNull(comparison, value)) {
+    return false;
+  }
+
   return (
     // Todo: support string comparison as well
     typeof value !== 'undefined' && Number(value) < Number(comparison.literal)
@@ -6,6 +10,10 @@ function propertyIsLessThan(comparison, value) {
 }
 
 function propertyIsGreaterThan(comparison, value) {
+  if (propertyIsNull(comparison, value)) {
+    return false;
+  }
+
   return (
     // Todo: support string comparison as well
     typeof value !== 'undefined' && Number(value) > Number(comparison.literal)
@@ -13,6 +21,10 @@ function propertyIsGreaterThan(comparison, value) {
 }
 
 function propertyIsBetween(comparison, value) {
+  if (propertyIsNull(comparison, value)) {
+    return false;
+  }
+
   // Todo: support string comparison as well
   const lowerBoundary = Number(comparison.lowerboundary);
   const upperBoundary = Number(comparison.upperboundary);
@@ -21,9 +33,10 @@ function propertyIsBetween(comparison, value) {
 }
 
 function propertyIsEqualTo(comparison, value) {
-  if (typeof value === 'undefined') {
+  if (propertyIsNull(comparison, value)) {
     return false;
   }
+
   /* eslint-disable-next-line eqeqeq */
   return value == comparison.literal;
 }
@@ -35,6 +48,7 @@ function propertyIsNotEqualTo(comparison, value) {
   if (propertyIsNull(comparison, value)) {
     return false;
   }
+
   return !propertyIsEqualTo(comparison, value);
 }
 
@@ -54,7 +68,7 @@ function propertyIsNull(comparison, value) {
 function propertyIsLike(comparison, value) {
   const pattern = comparison.literal;
 
-  if (typeof value === 'undefined') {
+  if (propertyIsNull(comparison, value)) {
     return false;
   }
 

--- a/src/Reader/filter.js
+++ b/src/Reader/filter.js
@@ -92,6 +92,8 @@ function createBinaryFilterComparison(element) {
     operator: element.localName.toLowerCase(),
     propertyname,
     literal,
+    // Match case attribute is true by default, so only make it false if the attribute value equals 'false'.
+    matchcase: element.getAttribute('matchCase') !== 'false',
   };
 }
 
@@ -105,6 +107,7 @@ function createBinaryFilterComparison(element) {
 function createIsLikeComparison(element) {
   const propertyname = getChildTextContent(element, 'PropertyName');
   const literal = getChildTextContent(element, 'Literal');
+
   return {
     type: TYPE_COMPARISON,
     operator: element.localName.toLowerCase(),
@@ -113,6 +116,8 @@ function createIsLikeComparison(element) {
     wildcard: element.getAttribute('wildCard'),
     singlechar: element.getAttribute('singleChar'),
     escapechar: element.getAttribute('escapeChar'),
+    // Match case attribute is true by default, so only make it false if the attribute value equals 'false'.
+    matchcase: element.getAttribute('matchCase') !== 'false',
   };
 }
 /**
@@ -148,6 +153,8 @@ function createIsBetweenComparison(element) {
     lowerboundary,
     upperboundary,
     propertyname,
+    // Match case attribute is true by default, so only make it false if the attribute value equals 'false'.
+    matchcase: element.getAttribute('matchCase') !== 'false',
   };
 }
 

--- a/test/Filter.test.js
+++ b/test/Filter.test.js
@@ -311,7 +311,7 @@ describe('filter rules', () => {
       });
     });
 
-    describe('Nested logical filter', () => {
+    it('Nested logical filter', () => {
       const harry = { properties: { name: 'Harry', age: 64 } };
       const sjenkie = { properties: { name: 'Sjenkie', age: 8 } };
 

--- a/test/Filter.test.js
+++ b/test/Filter.test.js
@@ -294,7 +294,7 @@ describe('filter rules', () => {
         operator: 'propertyisgreaterthan',
         propertyname: 'text',
         literal: 'Banana',
-        matchcase: false,
+        matchcase: true,
       };
       expect(filterSelector(filter, feature)).to.be.true;
     });

--- a/test/Filter.test.js
+++ b/test/Filter.test.js
@@ -207,7 +207,7 @@ describe('filter rules', () => {
         expect(testLike('%hoi%', 'hoi')).to.be.true;
       });
 
-      it('Case insensitive match with matchcase:false', () => {
+      it('Case insensitive match', () => {
         const feature = { properties: { text: 'TEST' } };
         const filter = {
           type: 'comparison',
@@ -274,19 +274,75 @@ describe('filter rules', () => {
     });
   });
 
-  // describe('Comparisons with strings', () => {
-  //   it('propertyisequalto with matchCase: false', () => {
-  //     const feature = { properties: { text: 'TEST' } };
-  //     const filter = {
-  //       type: 'comparison',
-  //       operator: 'propertyisequalto',
-  //       propertyname: 'text',
-  //       literal: 'test',
-  //       matchcase: false,
-  //     };
-  //     expect(filterSelector(filter, feature)).to.be.true;
-  //   });
-  // });
+  describe('Comparisons with strings', () => {
+    function testComparison(operator, filterText, featureText, matchcase) {
+      const feature = { properties: { text: featureText } };
+      const filter = {
+        type: 'comparison',
+        operator,
+        propertyname: 'text',
+        literal: filterText,
+        matchcase,
+      };
+      return filterSelector(filter, feature);
+    }
+
+    it('propertyisequalto with matchCase: false', () => {
+      expect(testComparison('propertyisequalto', 'TEST', 'test', false)).to.be
+        .true;
+    });
+
+    it('propertyislessthan with matchCase: false', () => {
+      expect(testComparison('propertyislessthan', 'some', 'SOME', false)).to.be
+        .false;
+    });
+
+    it('propertyisgreaterthan with matchCase: true', () => {
+      expect(testComparison('propertyisgreaterthan', 'monkey', 'Banana', true))
+        .to.be.false;
+    });
+
+    describe('propertyisbetween for strings', () => {
+      const filter = {
+        type: 'comparison',
+        operator: 'propertyisbetween',
+        propertyname: 'date',
+        lowerboundary: '1980-05-02',
+        upperboundary: '2021-06-27',
+        matchcase: true,
+      };
+
+      it('inside', () => {
+        const feature = { properties: { date: '1999-12-31' } };
+        expect(filterSelector(filter, feature)).to.be.true;
+      });
+
+      it('at lower bound', () => {
+        const feature = { properties: { date: '1980-05-02' } };
+        expect(filterSelector(filter, feature)).to.be.true;
+      });
+
+      it('below lower bound', () => {
+        const feature = { properties: { date: '1950-09-07' } };
+        expect(filterSelector(filter, feature)).to.be.false;
+      });
+
+      it('at upper bound', () => {
+        const feature = { properties: { date: '2021-06-27' } };
+        expect(filterSelector(filter, feature)).to.be.true;
+      });
+
+      it('at upper bound, simple date', () => {
+        const feature = { properties: { date: '2021-06-27' } };
+        expect(filterSelector(filter, feature)).to.be.true;
+      });
+
+      it('above upper bound', () => {
+        const feature = { properties: { date: '2222-12-21' } };
+        expect(filterSelector(filter, feature)).to.be.false;
+      });
+    });
+  });
 
   describe('Logical filters', () => {
     const lakeFilter = {

--- a/test/Filter.test.js
+++ b/test/Filter.test.js
@@ -170,6 +170,7 @@ describe('filter rules', () => {
         wildcard: '%',
         singlechar: '?',
         escapechar: '\\',
+        matchcase: true,
       };
 
       function testLike(pattern, value) {
@@ -204,6 +205,21 @@ describe('filter rules', () => {
 
       it('wildcard match without content true', () => {
         expect(testLike('%hoi%', 'hoi')).to.be.true;
+      });
+
+      it('Case insensitive match with matchcase:false', () => {
+        const feature = { properties: { text: 'TEST' } };
+        const filter = {
+          type: 'comparison',
+          operator: 'propertyislike',
+          propertyname: 'text',
+          literal: 'TeSt',
+          wildcard: '%',
+          singlechar: '?',
+          escapechar: '\\',
+          matchcase: false,
+        };
+        expect(filterSelector(filter, feature)).to.be.true;
       });
     });
   });

--- a/test/Filter.test.js
+++ b/test/Filter.test.js
@@ -274,6 +274,20 @@ describe('filter rules', () => {
     });
   });
 
+  // describe('Comparisons with strings', () => {
+  //   it('propertyisequalto with matchCase: false', () => {
+  //     const feature = { properties: { text: 'TEST' } };
+  //     const filter = {
+  //       type: 'comparison',
+  //       operator: 'propertyisequalto',
+  //       propertyname: 'text',
+  //       literal: 'test',
+  //       matchcase: false,
+  //     };
+  //     expect(filterSelector(filter, feature)).to.be.true;
+  //   });
+  // });
+
   describe('Logical filters', () => {
     const lakeFilter = {
       type: 'comparison',

--- a/test/Filter.test.js
+++ b/test/Filter.test.js
@@ -77,17 +77,6 @@ describe('filter rules', () => {
       expect(filterSelector(filter, featureuneq)).to.be.true;
     });
 
-    it('propertyisnotequalto should return false for null values', () => {
-      const featureeq = { properties: { PERIMETER: null } };
-      const filter = {
-        type: 'comparison',
-        operator: 'propertyisnotequalto',
-        propertyname: 'PERIMETER',
-        literal: 1071304933,
-      };
-      expect(filterSelector(filter, featureeq)).to.be.false;
-    });
-
     it('propertyisnull', () => {
       const featureeq = { properties: { PERIMETER: 1071304933 } };
       const filter = {
@@ -215,6 +204,56 @@ describe('filter rules', () => {
 
       it('wildcard match without content true', () => {
         expect(testLike('%hoi%', 'hoi')).to.be.true;
+      });
+    });
+  });
+
+  describe('Comparisons with missing/null values', () => {
+    it('propertyislike should return false for missing/null values', () => {
+      const emptyFeature = { properties: { text: null } };
+      const filter = {
+        type: 'comparison',
+        operator: 'propertyislike',
+        propertyname: 'text',
+        literal: 'something',
+        wildcard: '%',
+        singlechar: '?',
+        escapechar: '\\',
+      };
+      expect(filterSelector(filter, emptyFeature)).to.be.false;
+    });
+
+    it('propertyisbetween should return false for missing/null values', () => {
+      const emptyFeature = { properties: { age: null } };
+      const filter = {
+        type: 'comparison',
+        operator: 'propertyisbetween',
+        propertyname: 'age',
+        lowerboundary: '-100',
+        upperboundary: '100',
+      };
+      expect(filterSelector(filter, emptyFeature)).to.be.false;
+    });
+
+    const operators = [
+      'propertyisequalto',
+      'propertyisnotequalto',
+      'propertyislessthan',
+      'propertyislessthanorequalto',
+      'propertyisgreaterthan',
+      'propertyisgreaterthanorequalto',
+    ];
+
+    operators.forEach(operator => {
+      it(`Comparison should return false for missing/null value: ${operator}`, () => {
+        const emptyFeature = { properties: { TEMPERATURE: null } };
+        const filter = {
+          type: 'comparison',
+          operator,
+          propertyname: 'TEMPERATURE',
+          literal: '42',
+        };
+        expect(filterSelector(filter, emptyFeature)).to.be.false;
       });
     });
   });

--- a/test/Filter.test.js
+++ b/test/Filter.test.js
@@ -77,6 +77,17 @@ describe('filter rules', () => {
       expect(filterSelector(filter, featureuneq)).to.be.true;
     });
 
+    it('propertyisnotequalto should return false for null values', () => {
+      const featureeq = { properties: { PERIMETER: null } };
+      const filter = {
+        type: 'comparison',
+        operator: 'propertyisnotequalto',
+        propertyname: 'PERIMETER',
+        literal: 1071304933,
+      };
+      expect(filterSelector(filter, featureeq)).to.be.false;
+    });
+
     it('propertyisnull', () => {
       const featureeq = { properties: { PERIMETER: 1071304933 } };
       const filter = {

--- a/test/Filter.test.js
+++ b/test/Filter.test.js
@@ -424,7 +424,7 @@ describe('Custom property extraction', () => {
         {
           type: 'comparison',
           operator: 'propertyisgreaterthan',
-          propertyname: 'Age',
+          propertyname: 'age',
           literal: '40',
         },
       ],

--- a/test/Filter.test.js
+++ b/test/Filter.test.js
@@ -275,31 +275,28 @@ describe('filter rules', () => {
   });
 
   describe('Comparisons with strings', () => {
-    function testComparison(operator, filterText, featureText, matchcase) {
-      const feature = { properties: { text: featureText } };
+    it('propertyisequalto with matchCase: false', () => {
+      const feature = { properties: { text: 'test' } };
       const filter = {
         type: 'comparison',
-        operator,
+        operator: 'propertyisequalto',
         propertyname: 'text',
-        literal: filterText,
-        matchcase,
+        literal: 'TEST',
+        matchcase: false,
       };
-      return filterSelector(filter, feature);
-    }
-
-    it('propertyisequalto with matchCase: false', () => {
-      expect(testComparison('propertyisequalto', 'TEST', 'test', false)).to.be
-        .true;
-    });
-
-    it('propertyislessthan with matchCase: false', () => {
-      expect(testComparison('propertyislessthan', 'some', 'SOME', false)).to.be
-        .false;
+      expect(filterSelector(filter, feature)).to.be.true;
     });
 
     it('propertyisgreaterthan with matchCase: true', () => {
-      expect(testComparison('propertyisgreaterthan', 'monkey', 'Banana', true))
-        .to.be.false;
+      const feature = { properties: { text: 'monkey' } };
+      const filter = {
+        type: 'comparison',
+        operator: 'propertyisgreaterthan',
+        propertyname: 'text',
+        literal: 'Banana',
+        matchcase: false,
+      };
+      expect(filterSelector(filter, feature)).to.be.true;
     });
 
     describe('propertyisbetween for strings', () => {

--- a/test/Reader.Filter.test.js
+++ b/test/Reader.Filter.test.js
@@ -69,6 +69,22 @@ describe('Filter tests', () => {
     expect(filter.matchcase).to.be.false;
   });
 
+  it('PropertyIsNotEqualTo', () => {
+    const filterXml = `<StyledLayerDescriptor  xmlns="http://www.opengis.net/ogc"><Filter>
+      <PropertyIsNotEqualTo>
+        <PropertyName>PERIMETER</PropertyName>
+        <Literal>1071304933</Literal>
+      </PropertyIsNotEqualTo>
+    </Filter></StyledLayerDescriptor>`;
+
+    const { filter } = Reader(filterXml);
+    expect(filter.type).to.equal('comparison');
+    expect(filter.operator).to.equal('propertyisnotequalto');
+    expect(filter.propertyname).to.equal('PERIMETER');
+    expect(filter.literal).to.equal('1071304933');
+    expect(filter.matchcase).to.be.true;
+  });
+
   it('NOT filter', () => {
     const filterXml = `<StyledLayerDescriptor  xmlns="http://www.opengis.net/ogc"><Filter>
       <Not>

--- a/test/Reader.Filter.test.js
+++ b/test/Reader.Filter.test.js
@@ -22,6 +22,7 @@ describe('Filter tests', () => {
     expect(filter.propertyname).to.equal('AREA');
     expect(filter.lowerboundary).to.equal('1064866676');
     expect(filter.upperboundary).to.equal('1065512599');
+    expect(filter.matchcase).to.be.true;
   });
 
   it('PropertyIsNull', () => {
@@ -53,6 +54,19 @@ describe('Filter tests', () => {
     expect(filter.escapechar).to.equal('\\');
     expect(filter.propertyname).to.equal('name');
     expect(filter.literal).to.equal('j?ns%');
+    expect(filter.matchcase).to.be.true;
+  });
+
+  it('Parse matchCase attribute', () => {
+    const filterXml = `<StyledLayerDescriptor xmlns="http://www.opengis.net/ogc"><Filter>
+    <PropertyIsLike matchCase="false" wildCard="%" singleChar="?" escapeChar="\\">
+      <PropertyName>name</PropertyName>
+      <Literal>j?ns%</Literal>
+    </PropertyIsLike>
+  </Filter></StyledLayerDescriptor>`;
+
+    const { filter } = Reader(filterXml);
+    expect(filter.matchcase).to.be.false;
   });
 
   it('NOT filter', () => {
@@ -99,6 +113,7 @@ describe('Filter tests', () => {
       expect(filter.operator).to.equal('propertyisequalto');
       expect(filter.propertyname).to.equal('name');
       expect(filter.literal).to.equal('My simple Polygon');
+      expect(filter.matchcase).to.be.true;
     });
     it('rules have filter for Hover Styler not_or', () => {
       const { filter } = result.layers['0'].styles['1'].featuretypestyles[
@@ -115,12 +130,14 @@ describe('Filter tests', () => {
       expect(orPredicate1.operator).to.equal('propertyisequalto');
       expect(orPredicate1.propertyname).to.equal('PERIMETER');
       expect(orPredicate1.literal).to.equal('1071304933');
+      expect(orPredicate1.matchcase).to.be.true;
 
       const orPredicate2 = predicate.predicates[1];
       expect(orPredicate2.type).to.equal('comparison');
       expect(orPredicate2.operator).to.equal('propertyislessthan');
       expect(orPredicate2.propertyname).to.equal('AREA');
       expect(orPredicate2.literal).to.equal('1065512599');
+      expect(orPredicate2.matchcase).to.be.true;
     });
   });
 });


### PR DESCRIPTION
This PR fixes several issues with comparison operations within filters.
* Comparison operators now support comparing string values.
* Comparisons now use the attribute `matchCase` on comparison operators (default: true --> case sensitive comparison).
* Improve handling of null values: a comparison will always return false when a feature attribute is null or undefined.
