### PR TITLE
Graphicstroke placement

### DIFF
--- a/docs/assets/hoogspanning.js
+++ b/docs/assets/hoogspanning.js
@@ -66,12 +66,26 @@ function applySLD(vectorLayer, text) {
 }
 
 function loadSld(mode) {
-  const sldUrl = mode === 'DEMO_MARK'
-    ? 'assets/sld-hoogspanning.xml'
-    : 'assets/sld-external-graphic-mark.xml';
-  fetch(sldUrl)
-    .then(response => response.text())
-    .then(text => editor.setValue(text));
+  let sldUrl = null;
+  
+  switch (mode) {
+    case 'DEMO_MARK':
+      sldUrl = 'assets/sld-hoogspanning.xml';
+      break;
+    case 'DEMO_EXTERNALGRAPHIC':
+      sldUrl = 'assets/sld-external-graphic-mark.xml';
+      break;
+    case 'DEMO_POINTPLACEMENT':
+      sldUrl = 'assets/sld-graphic-mark-placement.xml';
+      break;
+
+  }
+
+  if (sldUrl) {
+    fetch(sldUrl)
+      .then(response => response.text())
+      .then(text => editor.setValue(text));
+  }
 }
 
 loadSld('DEMO_MARK');
@@ -86,6 +100,7 @@ editor.on('change', cm => {
 // SLD switch handlers.
 const optionMark = document.querySelector('#option-mark').parentElement;
 const optionExternalGraphic = document.querySelector('#option-exgraphic').parentElement;
+const optionPointPlacement = document.querySelector('#option-pointplacement').parentElement;
 
 document.querySelectorAll('.option-input input').forEach(inputNode => {
   inputNode.addEventListener('change', evt => {
@@ -93,10 +108,17 @@ document.querySelectorAll('.option-input input').forEach(inputNode => {
       loadSld('DEMO_MARK');
       optionMark.classList.add('option-checked');
       optionExternalGraphic.classList.remove('option-checked');
-    } else {
+      optionPointPlacement.classList.remove('option-checked');
+    } else if (evt.target.value === 'DEMO_EXTERNALGRAPHIC') {
       loadSld('DEMO_EXTERNALGRAPHIC');
       optionMark.classList.remove('option-checked');
       optionExternalGraphic.classList.add('option-checked');
+      optionPointPlacement.classList.remove('option-checked');
+    } else if (evt.target.value === 'DEMO_POINTPLACEMENT') {
+      loadSld('DEMO_POINTPLACEMENT');
+      optionMark.classList.remove('option-checked');
+      optionExternalGraphic.classList.remove('option-checked');
+      optionPointPlacement.classList.add('option-checked');
     }
   });
 });

--- a/docs/assets/sld-external-graphic-mark.xml
+++ b/docs/assets/sld-external-graphic-mark.xml
@@ -26,6 +26,9 @@
                     <Format>image/png</Format>
                   </ExternalGraphic>
                   <Size>24</Size>
+                  <Rotation>
+                    <ogc:Literal>90</ogc:Literal>
+                  </Rotation>
                 </Graphic>
               </GraphicStroke>
               <CssParameter name="stroke-dasharray">24 12</CssParameter>

--- a/docs/assets/sld-graphic-mark-placement.xml
+++ b/docs/assets/sld-graphic-mark-placement.xml
@@ -1,0 +1,61 @@
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>Hoogspanning</Name>
+    <UserStyle>
+      <Name>Hoogspanning</Name>
+      <FeatureTypeStyle>
+        <Rule>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#000000</CssParameter>
+              <CssParameter name="stroke-width">1</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+          <LineSymbolizer>
+            <VendorOption name="placement">firstPoint</VendorOption>
+            <Stroke>
+              <GraphicStroke>
+                <Graphic>
+                  <Mark>
+                    <WellKnownName>triangle</WellKnownName>
+                    <Fill>
+                      <CssParameter name="fill">#00AA00</CssParameter>
+                    </Fill>
+                    <Stroke/>
+                  </Mark>
+                  <Size>12</Size>
+                  <Rotation>
+                    <ogc:Literal>270</ogc:Literal>
+                  </Rotation>
+                </Graphic>
+              </GraphicStroke>
+            </Stroke>
+          </LineSymbolizer>
+          <LineSymbolizer>
+            <VendorOption name="placement">lastPoint</VendorOption>
+            <Stroke>
+              <GraphicStroke>
+                <Graphic>
+                  <Mark>
+                    <WellKnownName>triangle</WellKnownName>
+                    <Fill>
+                      <CssParameter name="fill">#FF0000</CssParameter>
+                    </Fill>
+                    <Stroke/>
+                  </Mark>
+                  <Size>12</Size>
+                  <Rotation>
+                    <ogc:Literal>90</ogc:Literal>
+                  </Rotation>
+                </Graphic>
+              </GraphicStroke>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/docs/hoogspanning.html
+++ b/docs/hoogspanning.html
@@ -36,11 +36,15 @@ nav_order: 3
 <div class="button-box">
     <div class="option-input option-checked">
       <input id="option-mark" name="sld-options" type="radio" value="DEMO_MARK" checked></input>
-      <label for="option-mark">GraphicStroke: Mark</label>
+      <label for="option-mark">Mark</label>
     </div>
     <div class="option-input">
       <input id="option-exgraphic" name="sld-options" type="radio" value="DEMO_EXTERNALGRAPHIC"></input>
-      <label for="option-exgraphic">GraphicStroke: ExternalGraphic</label>
+      <label for="option-exgraphic">ExternalGraphic</label>
+    </div>
+    <div class="option-input">
+      <input id="option-pointplacement" name="sld-options" type="radio" value="DEMO_POINTPLACEMENT"></input>
+      <label for="option-pointplacement">Vendor option: pointPlacement</label>
     </div>
 </div>
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,3 +7,8 @@ export const DEFAULT_MARK_SIZE = 6; // pixels
 // SLD Spec: Default size for ExternalGraphic with an unknown native size,
 // like SVG without dimensions, should be 16 pixels.
 export const DEFAULT_EXTERNALGRAPHIC_SIZE = 16; // pixels
+
+// QGIS Graphic stroke placement options
+export const PLACEMENT_DEFAULT = 'PLACEMENT_DEFAULT';
+export const PLACEMENT_FIRSTPOINT = 'PLACEMENT_FIRSTPOINT';
+export const PLACEMENT_LASTPOINT = 'PLACEMENT_LASTPOINT';

--- a/src/styles/geometryCalcs.js
+++ b/src/styles/geometryCalcs.js
@@ -1,5 +1,7 @@
 import { containsCoordinate } from 'ol/extent';
 
+import { PLACEMENT_FIRSTPOINT, PLACEMENT_LASTPOINT } from '../constants';
+
 // eslint-disable-next-line import/prefer-default-export
 export function splitLineString(geometry, graphicSpacing, options) {
   function calculatePointsDistance(coord1, coord2) {
@@ -37,6 +39,21 @@ export function splitLineString(geometry, graphicSpacing, options) {
 
   const coords = geometry.getCoordinates();
 
+  // Handle first point placement case.
+  if (options.placement === PLACEMENT_FIRSTPOINT) {
+    const p1 = coords[0];
+    const p2 = coords[1];
+    return [[p1[0], p1[1], calculateAngle(p1, p2, options.invertY)]];
+  }
+
+  // Handle last point placement case.
+  if (options.placement === PLACEMENT_LASTPOINT) {
+    const p1 = coords[coords.length - 2];
+    const p2 = coords[coords.length - 1];
+    return [[p2[0], p2[1], calculateAngle(p1, p2, options.invertY)]];
+  }
+
+  // Without placement vendor options, draw regularly spaced GraphicStroke markers.
   const splitPoints = [];
   let coordIndex = 0;
   let startPoint = coords[coordIndex];

--- a/src/styles/geometryCalcs.js
+++ b/src/styles/geometryCalcs.js
@@ -23,17 +23,17 @@ export function splitLineString(geometry, graphicSpacing, options) {
   }
 
   /**
-   * Calculate the angle of a vector in radians clockwise from the north.
-   * Example, north-pointing vector: (0,0) -> (0,1) --> 0 radians.
+   * Calculate the angle of a vector in radians clockwise from the positive x-axis.
+   * Example: (0,0) -> (1,1) --> -pi/4 radians.
    * @param {Array<number>} p1 Start of the line segment as [x,y].
    * @param {Array<number>} p2 End of the line segment as [x,y].
    * @param {boolean} invertY If true, calculate with Y-axis pointing downwards.
-   * @returns {number} Angle in radians, clockwise from the north.
+   * @returns {number} Angle in radians, clockwise from the positive x-axis.
    */
   function calculateAngle(p1, p2, invertY) {
     const dX = p2[0] - p1[0];
     const dY = p2[1] - p1[1];
-    let angle = Math.PI / 2 - Math.atan2(invertY ? -dY : dY, dX);
+    let angle = -Math.atan2(invertY ? -dY : dY, dX);
     return angle;
   }
 

--- a/src/styles/geometryCalcs.js
+++ b/src/styles/geometryCalcs.js
@@ -33,7 +33,7 @@ export function splitLineString(geometry, graphicSpacing, options) {
   function calculateAngle(p1, p2, invertY) {
     const dX = p2[0] - p1[0];
     const dY = p2[1] - p1[1];
-    let angle = -Math.atan2(invertY ? -dY : dY, dX);
+    const angle = -Math.atan2(invertY ? -dY : dY, dX);
     return angle;
   }
 

--- a/src/styles/geometryCalcs.js
+++ b/src/styles/geometryCalcs.js
@@ -20,28 +20,28 @@ export function splitLineString(geometry, graphicSpacing, options) {
     return [x, y];
   }
 
-  function calculateAngle(startNode, nextNode, alwaysUp) {
-    const x = startNode[0] - nextNode[0];
-    const y = startNode[1] - nextNode[1];
-    let angle = Math.atan(x / y);
-    if (!alwaysUp) {
-      if (y > 0) {
-        angle += Math.PI;
-      } else if (x < 0) {
-        angle += Math.PI * 2;
-      }
-      // angle = y > 0 ? angle + Math.PI : x < 0 ? angle + Math.PI * 2 : angle;
-    }
+  /**
+   * Calculate the angle of a vector in radians clockwise from the north.
+   * Example, north-pointing vector: (0,0) -> (0,1) --> 0 radians.
+   * @param {Array<number>} p1 Start of the line segment as [x,y].
+   * @param {Array<number>} p2 End of the line segment as [x,y].
+   * @param {boolean} invertY If true, calculate with Y-axis pointing downwards.
+   * @returns {number} Angle in radians, clockwise from the north.
+   */
+  function calculateAngle(p1, p2, invertY) {
+    const dX = p2[0] - p1[0];
+    const dY = p2[1] - p1[1];
+    let angle = Math.PI / 2 - Math.atan2(invertY ? -dY : dY, dX);
     return angle;
   }
 
-  const splitPoints = [];
   const coords = geometry.getCoordinates();
 
+  const splitPoints = [];
   let coordIndex = 0;
   let startPoint = coords[coordIndex];
   let nextPoint = coords[coordIndex + 1];
-  let angle = calculateAngle(startPoint, nextPoint, options.alwaysUp);
+  let angle = calculateAngle(startPoint, nextPoint, options.invertY);
 
   const n = Math.ceil(geometry.getLength() / graphicSpacing);
   const segmentLength = geometry.getLength() / n;
@@ -61,7 +61,7 @@ export function splitLineString(geometry, graphicSpacing, options) {
       if (coordIndex < coords.length - 1) {
         startPoint = coords[coordIndex];
         nextPoint = coords[coordIndex + 1];
-        angle = calculateAngle(startPoint, nextPoint, options.alwaysUp);
+        angle = calculateAngle(startPoint, nextPoint, options.invertY);
         i -= 1;
         // continue;
       } else {

--- a/src/styles/graphicStrokeStyle.js
+++ b/src/styles/graphicStrokeStyle.js
@@ -2,7 +2,13 @@ import { Style } from 'ol/style';
 import { toContext } from 'ol/render';
 import { Point, LineString } from 'ol/geom';
 
-import { DEFAULT_MARK_SIZE, DEFAULT_EXTERNALGRAPHIC_SIZE } from '../constants';
+import {
+  DEFAULT_MARK_SIZE,
+  DEFAULT_EXTERNALGRAPHIC_SIZE,
+  PLACEMENT_DEFAULT,
+  PLACEMENT_FIRSTPOINT,
+  PLACEMENT_LASTPOINT,
+} from '../constants';
 import evaluate from '../olEvaluator';
 import getPointStyle from './pointStyle';
 import { calculateGraphicSpacing } from './styleUtils';
@@ -51,7 +57,8 @@ function renderStrokeMarks(
   pixelCoords,
   graphicSpacing,
   pointStyle,
-  pixelRatio
+  pixelRatio,
+  options
 ) {
   if (!pixelCoords) {
     return;
@@ -91,6 +98,7 @@ function renderStrokeMarks(
       invertY: true, // Pixel y-coordinates increase downwards in screen space.
       midPoints: false,
       extent: render.extent_,
+      placement: options.placement,
     }
   );
 
@@ -117,6 +125,19 @@ export function getGraphicStrokeRenderer(linesymbolizer, getProperty) {
   }
 
   const { graphicstroke } = linesymbolizer.stroke;
+
+  const options = {
+    placement: PLACEMENT_DEFAULT,
+  };
+
+  // QGIS vendor options to override graphicstroke symbol placement.
+  if (linesymbolizer.vendoroption) {
+    if (linesymbolizer.vendoroption.placement === 'firstPoint') {
+      options.placement = PLACEMENT_FIRSTPOINT;
+    } else if (linesymbolizer.vendoroption.placement === 'lastPoint') {
+      options.placement = PLACEMENT_LASTPOINT;
+    }
+  }
 
   return (pixelCoords, renderState) => {
     // Abort when feature geometry is (Multi)Point.
@@ -159,7 +180,8 @@ export function getGraphicStrokeRenderer(linesymbolizer, getProperty) {
       pixelCoords,
       graphicSpacing,
       pointStyle,
-      pixelRatio
+      pixelRatio,
+      options
     );
   };
 }

--- a/src/styles/graphicStrokeStyle.js
+++ b/src/styles/graphicStrokeStyle.js
@@ -87,11 +87,15 @@ function renderStrokeMarks(
   const splitPoints = splitLineString(
     new LineString(pixelCoords),
     graphicSpacing * pixelRatio,
-    { alwaysUp: true, midPoints: false, extent: render.extent_ }
+    {
+      invertY: true, // Pixel y-coordinates increase downwards in screen space.
+      midPoints: false,
+      extent: render.extent_,
+    }
   );
 
   splitPoints.forEach(point => {
-    const splitPointAngle = image.getRotation() - point[2];
+    const splitPointAngle = image.getRotation() + point[2];
     render.setImageStyle2(image, splitPointAngle);
     render.drawPoint(new Point([point[0] / pixelRatio, point[1] / pixelRatio]));
   });

--- a/src/styles/linePointStyle.js
+++ b/src/styles/linePointStyle.js
@@ -14,7 +14,6 @@ function getLineMidpoint(geometry) {
   // a point-to-point distance along the line equal to half line length.
   // This results in three points. Take the middle point.
   const splitPoints = splitLineString(geometry, geometry.getLength() / 2, {
-    alwaysUp: true,
     midPoints: false,
   });
   const [x, y] = splitPoints[1];

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -1,4 +1,4 @@
-/* global describe it expect before */
+/* global describe it expect before beforeEach */
 import Reader from '../src/Reader';
 import { sld } from './data/test.sld';
 import { sld11 } from './data/test11.sld';
@@ -324,8 +324,8 @@ describe('SLD v1.1.0 GraphicStroke properties', () => {
 describe('Parse vendor options', () => {
   let style;
   beforeEach(() => {
-    const sld = Reader(graphicStrokeVendorOption);
-    style = sld.layers[0].styles[0].featuretypestyles[0];
+    const parsedSld = Reader(graphicStrokeVendorOption);
+    [style] = parsedSld.layers[0].styles[0].featuretypestyles;
   });
 
   it('Sections without vendor options have no .vendoroption prop', () => {

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -5,6 +5,7 @@ import { sld11 } from './data/test11.sld';
 import { dynamicSld } from './data/dynamic.sld';
 import { graphicstrokeSymbolizerSld } from './data/graphicstrokeSymbolizer.sld';
 import { graphicStrokeWithGap } from './data/graphicstroke-with-gap.sld';
+import graphicStrokeVendorOption from './data/graphicstroke-vendoroption.sld';
 
 let result;
 
@@ -224,9 +225,9 @@ describe('Graphicstroke symbolizer', () => {
     expect(linesymbolizer2.stroke.styling.strokeDasharray).to.equal('2 6');
   });
   it('rule linesymbolizer has graphicstroke', () => {
-    const { stroke } = result.layers['0'].styles['0'].featuretypestyles[
-      '0'
-    ].rules['0'].linesymbolizer['1'];
+    const { stroke } =
+      result.layers['0'].styles['0'].featuretypestyles['0'].rules['0']
+        .linesymbolizer['1'];
     expect(stroke.graphicstroke).to.be.an.instanceof(Object);
     expect(stroke.graphicstroke.graphic).to.be.an.instanceof(Object);
     expect(stroke.graphicstroke.graphic).to.have.property('mark');
@@ -317,5 +318,25 @@ describe('SLD v1.1.0 GraphicStroke properties', () => {
 
   it('Has intialgap', () => {
     expect(graphicStroke.initialgap).to.equal(6);
+  });
+});
+
+describe('Parse vendor options', () => {
+  let style;
+  beforeEach(() => {
+    const sld = Reader(graphicStrokeVendorOption);
+    style = sld.layers[0].styles[0].featuretypestyles[0];
+  });
+
+  it('Sections without vendor options have no .vendoroption prop', () => {
+    const symbolizer = style.rules[0].linesymbolizer[0];
+    expect(symbolizer.vendoroption).to.be.undefined;
+  });
+
+  it('Parse vendor options into a .vendoroption prop', () => {
+    const symbolizer = style.rules[0].linesymbolizer[1];
+    expect(symbolizer.vendoroption).to.deep.equal({
+      placement: 'lastPoint',
+    });
   });
 });

--- a/test/data/graphicstroke-vendoroption.sld.js
+++ b/test/data/graphicstroke-vendoroption.sld.js
@@ -5,7 +5,7 @@ const graphicStrokeVendorOption = `<?xml version="1.0" encoding="UTF-8"?>
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   version="1.0.0"
   xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
-	<NamedLayer>
+  <NamedLayer>
     <Name>LinearDimension</Name>
     <UserStyle>
       <Name>LinearDimension</Name>

--- a/test/data/graphicstroke-vendoroption.sld.js
+++ b/test/data/graphicstroke-vendoroption.sld.js
@@ -1,0 +1,66 @@
+const graphicStrokeVendorOption = `<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  version="1.0.0"
+  xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+	<NamedLayer>
+    <Name>LinearDimension</Name>
+    <UserStyle>
+      <Name>LinearDimension</Name>
+      <FeatureTypeStyle>
+        <Rule>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#000000</CssParameter>
+              <CssParameter name="stroke-width">2</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+          <LineSymbolizer>
+            <VendorOption name="placement">lastPoint</VendorOption>
+            <Stroke>
+              <GraphicStroke>
+                <Graphic>
+                  <Mark>
+                    <WellKnownName>triangle</WellKnownName>
+                    <Fill>
+                      <CssParameter name="fill">#000000</CssParameter>
+                    </Fill>
+                    <Stroke/>
+                  </Mark>
+                  <Size>13</Size>
+                  <Rotation>
+                    <ogc:Literal>90</ogc:Literal>
+                  </Rotation>
+                </Graphic>
+              </GraphicStroke>
+            </Stroke>
+          </LineSymbolizer>
+          <LineSymbolizer>
+            <VendorOption name="placement">firstPoint</VendorOption>
+            <Stroke>
+              <GraphicStroke>
+                <Graphic>
+                  <Mark>
+                    <WellKnownName>triangle</WellKnownName>
+                    <Fill>
+                      <CssParameter name="fill">#000000</CssParameter>
+                    </Fill>
+                    <Stroke/>
+                  </Mark>
+                  <Size>13</Size>
+                  <Rotation>
+                    <ogc:Literal>270</ogc:Literal>
+                  </Rotation>
+                </Graphic>
+              </GraphicStroke>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>`;
+
+export default graphicStrokeVendorOption;


### PR DESCRIPTION
* Fix bug: according to the SLD spec, the horizontal center line of ExternalGraphic markers should follow the line string. Old behavior was to let the vertical center line follow the line string.
* Implement two QGIS vendorOptions for ExternalGraphic placement: firstPoint and lastPoint. Also added a demo page to demonstrate.

Fixes #116 