### PR TITLE
Fix GraphicStroke crash on multipart geometries

### DIFF
--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -2197,7 +2197,8 @@
           pixelCoordsChildArray,
           graphicSpacing,
           pointStyle,
-          pixelRatio
+          pixelRatio,
+          options
         );
       });
       return;

--- a/src/styles/graphicStrokeStyle.js
+++ b/src/styles/graphicStrokeStyle.js
@@ -74,7 +74,8 @@ function renderStrokeMarks(
         pixelCoordsChildArray,
         graphicSpacing,
         pointStyle,
-        pixelRatio
+        pixelRatio,
+        options
       );
     });
     return;


### PR DESCRIPTION
Fixes a crash that happens when you a GraphicStroke symbolizer is applied to a MultiLine or MultiPolygon geometry.

Fixes #119.