### PR TITLE
Parsing improvements

### DIFF
--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -547,6 +547,7 @@
       obj.rules.push(rule);
     },
     Name: addPropWithTextContent,
+    Title: addPropWithTextContent,
     MaxScaleDenominator: addPropWithTextContent,
     MinScaleDenominator: addPropWithTextContent},
     FilterParsers,

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -549,6 +549,7 @@
     },
     Name: addPropWithTextContent,
     Title: addPropWithTextContent,
+    Abstract: addPropWithTextContent,
     MaxScaleDenominator: addPropWithTextContent,
     MinScaleDenominator: addPropWithTextContent},
     FilterParsers,

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -535,6 +535,7 @@
       obj.styles.push(style);
     },
     FeatureTypeStyle: function (element, obj) {
+      obj.featuretypestyle = obj.featuretypestyle || [];
       var featuretypestyle = {
         rules: [],
       };

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -269,6 +269,7 @@ const parsers = {
     obj.styles.push(style);
   },
   FeatureTypeStyle: (element, obj) => {
+    obj.featuretypestyle = obj.featuretypestyle || [];
     const featuretypestyle = {
       rules: [],
     };

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -281,6 +281,7 @@ const parsers = {
     obj.rules.push(rule);
   },
   Name: addPropWithTextContent,
+  Title: addPropWithTextContent,
   MaxScaleDenominator: addPropWithTextContent,
   MinScaleDenominator: addPropWithTextContent,
   ...FilterParsers,

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -283,6 +283,7 @@ const parsers = {
   },
   Name: addPropWithTextContent,
   Title: addPropWithTextContent,
+  Abstract: addPropWithTextContent,
   MaxScaleDenominator: addPropWithTextContent,
   MinScaleDenominator: addPropWithTextContent,
   ...FilterParsers,

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -88,7 +88,7 @@ describe('Reads xml', () => {
     expect(pointSymbolizers[0].graphic.mark.wellknownname).to.equal('hexagon');
   });
 
-  it('Parses title elements', () => {
+  it('Parses Title elements', () => {
     const layer = result.layers[0];
     expect(layer.title).to.be.undefined;
 
@@ -100,6 +100,20 @@ describe('Reads xml', () => {
 
     const rule = featureTypeStyle.rules[0];
     expect(rule.title).to.equal('title');
+  });
+
+  it('Parses Abstract elements', () => {
+    const layer = result.layers[0];
+    expect(layer.abstract).to.be.undefined;
+
+    const userStyle = layer.styles[0];
+    expect(userStyle.abstract).to.equal('');
+
+    const featureTypeStyle = userStyle.featuretypestyles[0];
+    expect(featureTypeStyle.abstract).to.equal('abstract');
+
+    const rule = featureTypeStyle.rules[0];
+    expect(rule.abstract).to.equal('Abstract');
   });
 });
 

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -87,6 +87,20 @@ describe('Reads xml', () => {
     expect(pointSymbolizers[0].graphic.mark).to.have.property('wellknownname');
     expect(pointSymbolizers[0].graphic.mark.wellknownname).to.equal('hexagon');
   });
+
+  it('Parses title elements', () => {
+    const layer = result.layers[0];
+    expect(layer.title).to.be.undefined;
+
+    const userStyle = layer.styles[0];
+    expect(userStyle.title).to.equal('Default Styler (zoom in to see more objects)');
+
+    const featureTypeStyle = userStyle.featuretypestyles[0];
+    expect(featureTypeStyle.title).to.equal('Test style');
+
+    const rule = featureTypeStyle.rules[0];
+    expect(rule.title).to.equal('title');
+  });
 });
 
 describe('Reads xml sld 11', () => {

--- a/test/data/test.sld.js
+++ b/test/data/test.sld.js
@@ -15,7 +15,7 @@ export const sld = `<?xml version="1.0" encoding="UTF-8"?>
       <sld:IsDefault>1</sld:IsDefault>
       <sld:FeatureTypeStyle>
         <sld:Name>testStyleName</sld:Name>
-        <sld:Title>title</sld:Title>
+        <sld:Title>Test style</sld:Title>
         <sld:Abstract>abstract</sld:Abstract>
         <sld:FeatureTypeName>Feature</sld:FeatureTypeName>
         <sld:SemanticTypeIdentifier>generic:geometry</sld:SemanticTypeIdentifier>


### PR DESCRIPTION
* Parses Abstract and Title elements (which are part of the SLD 1.0.0 spec).
* Handles possible case where FeatureTypeStyles are not present.

Fixes #83
Fixes #123 

