### PR TITLE
Point not rendered in mixed geometry layer

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,6 +41,7 @@
     "operator-linebreak": "off",
     "implicit-arrow-linebreak": "off",
     "object-curly-newline": "off",
-    "no-underscore-dangle": "off"
+    "no-underscore-dangle": "off",
+    "prefer-destructuring": "off"
   }
 }

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -1983,6 +1983,10 @@
     }
 
     var olStyle = cachedPointStyle(symbolizer);
+
+    // Reset previous calculated point geometry left by evaluating point style for a line or polygon feature.
+    olStyle.setGeometry(null);
+
     var olImage = olStyle.getImage();
 
     // Apply dynamic values to the cached OL style instance before returning it.
@@ -1991,7 +1995,8 @@
     var graphic = symbolizer.graphic;
     var size = graphic.size;
     if (size && size.type === 'expression') {
-      var sizeValue = Number(evaluate(size, feature, getProperty)) || DEFAULT_MARK_SIZE;
+      var sizeValue =
+        Number(evaluate(size, feature, getProperty)) || DEFAULT_MARK_SIZE;
 
       if (graphic.externalgraphic && graphic.externalgraphic.onlineresource) {
         var height = olImage.getSize()[1];
@@ -2016,7 +2021,8 @@
     // --- Update dynamic rotation ---
     var rotation = graphic.rotation;
     if (rotation && rotation.type === 'expression') {
-      var rotationDegrees = Number(evaluate(rotation, feature, getProperty)) || 0.0;
+      var rotationDegrees =
+        Number(evaluate(rotation, feature, getProperty)) || 0.0;
       // Note: OL angles are in radians.
       var rotationRadians = (Math.PI * rotationDegrees) / 180.0;
       olImage.setRotation(rotationRadians);

--- a/src/styles/pointStyle.js
+++ b/src/styles/pointStyle.js
@@ -108,6 +108,10 @@ function getPointStyle(symbolizer, feature, getProperty) {
   }
 
   const olStyle = cachedPointStyle(symbolizer);
+
+  // Reset previous calculated point geometry left by evaluating point style for a line or polygon feature.
+  olStyle.setGeometry(null);
+
   let olImage = olStyle.getImage();
 
   // Apply dynamic values to the cached OL style instance before returning it.
@@ -116,7 +120,8 @@ function getPointStyle(symbolizer, feature, getProperty) {
   const { graphic } = symbolizer;
   const { size } = graphic;
   if (size && size.type === 'expression') {
-    const sizeValue = Number(evaluate(size, feature, getProperty)) || DEFAULT_MARK_SIZE;
+    const sizeValue =
+      Number(evaluate(size, feature, getProperty)) || DEFAULT_MARK_SIZE;
 
     if (graphic.externalgraphic && graphic.externalgraphic.onlineresource) {
       const height = olImage.getSize()[1];
@@ -141,7 +146,8 @@ function getPointStyle(symbolizer, feature, getProperty) {
   // --- Update dynamic rotation ---
   const { rotation } = graphic;
   if (rotation && rotation.type === 'expression') {
-    const rotationDegrees = Number(evaluate(rotation, feature, getProperty)) || 0.0;
+    const rotationDegrees =
+      Number(evaluate(rotation, feature, getProperty)) || 0.0;
     // Note: OL angles are in radians.
     const rotationRadians = (Math.PI * rotationDegrees) / 180.0;
     olImage.setRotation(rotationRadians);


### PR DESCRIPTION
This PR fixes #132 where a point symbolizer does not render points in a layer with mixed point/line/polygon geometries.