### PR TITLE
Graphicfill improvements

### DIFF
--- a/docs/assets/sld-provincies.xml
+++ b/docs/assets/sld-provincies.xml
@@ -43,10 +43,10 @@
               <se:GraphicFill>
                 <se:Graphic>
                   <se:Mark>
-                    <se:WellKnownName>square</se:WellKnownName>
+                    <se:WellKnownName>cross</se:WellKnownName>
                     <se:Stroke>
                       <se:SvgParameter name="stroke">#3544ea</se:SvgParameter>
-                      <se:CssParameter name="stroke-width">2</se:CssParameter>
+                      <se:CssParameter name="stroke-width">1</se:CssParameter>
                     </se:Stroke>
                   </se:Mark>
                   <se:Size>8</se:Size>

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -2491,6 +2491,50 @@
     }
   }
 
+  /**
+   * Scale mark graphic fill symbol with given scale factor to improve mark fill rendering.
+   * Scale factor will be applied to stroke width depending on the original value for visual fidelity.
+   * @param {object} graphicfill GraphicFill symbolizer object.
+   * @param {number} scaleFactor Scale factor.
+   * @returns {object} A new GraphifFill symbolizer object with scale factor applied.
+   */
+  function scaleMarkGraphicFill(graphicfill, scaleFactor) {
+    if (!graphicfill.graphic) {
+      return graphicfill;
+    }
+
+    // Create a deep clone of the original symbolizer.
+    var newFill = JSON.parse(JSON.stringify(graphicfill));
+    var graphic = newFill.graphic;
+    var oriSize = Number(graphic.size) || DEFAULT_MARK_SIZE;
+    graphic.size = scaleFactor * oriSize;
+    var mark = graphic.mark;
+    if (mark && mark.stroke) {
+      // Apply SLD defaults to stroke parameters.
+      // Todo: do this at the SLDReader parsing stage already.
+      if (!mark.stroke.styling) {
+        mark.stroke.styling = {
+          stroke: 'black',
+          strokeWidth: 1.0,
+        };
+      }
+
+      if (!mark.stroke.styling.strokeWidth) {
+        mark.stroke.styling.strokeWidth =
+          Number(mark.stroke.styling.strokeWidth) || 1;
+      }
+
+      // If original stroke width is 1 or less, do not scale it.
+      // This gives better visual results than using a stroke width of 2 and downsizing.
+      var oriStrokeWidth = mark.stroke.styling.strokeWidth;
+      if (oriStrokeWidth > 1) {
+        mark.stroke.styling.strokeWidth = scaleFactor * oriStrokeWidth;
+      }
+    }
+
+    return newFill;
+  }
+
   function getMarkGraphicFill(symbolizer) {
     var ref = symbolizer.fill;
     var graphicfill = ref.graphicfill;
@@ -2499,20 +2543,27 @@
     var canvasSize = graphicSize * has.DEVICE_PIXEL_RATIO;
     var fill = null;
 
+    // The graphic symbol will be rendered at a larger size and then scaled back to the graphic size.
+    // This is done to mitigate visual artifacts that occur when drawing between pixels.
+    var scaleFactor = 2.0;
+
     try {
-      var canvas = document.createElement('canvas');
-      canvas.width = canvasSize;
-      canvas.height = canvasSize;
-      var context = canvas.getContext('2d');
+      var scaledCanvas = document.createElement('canvas');
+      scaledCanvas.width = canvasSize * scaleFactor;
+      scaledCanvas.height = canvasSize * scaleFactor;
+      var context = scaledCanvas.getContext('2d');
 
       // Point symbolizer function expects an object with a .graphic property.
       // The point symbolizer is stored as graphicfill in the polygon symbolizer.
-      var pointStyle = getPointStyle(graphicfill);
+      var scaledGraphicFill = scaleMarkGraphicFill(graphicfill, scaleFactor);
+      var pointStyle = getPointStyle(scaledGraphicFill);
 
       // Let OpenLayers draw a point with the given point style on the temp canvas.
       // Note: OL rendering context size params are always in css pixels, while the temp canvas may
       // be larger depending on the device pixel ratio.
-      var olContext = render.toContext(context, { size: [graphicSize, graphicSize] });
+      var olContext = render.toContext(context, {
+        size: [graphicSize * scaleFactor, graphicSize * scaleFactor],
+      });
 
       // Disable image smoothing to ensure crisp graphic fill pattern.
       context.imageSmoothingEnabled = false;
@@ -2520,8 +2571,8 @@
       // Let OpenLayers draw the symbol to the canvas directly.
       olContext.setStyle(pointStyle);
 
-      var centerX = graphicSize / 2;
-      var centerY = graphicSize / 2;
+      var centerX = scaleFactor * (graphicSize / 2);
+      var centerY = scaleFactor * (graphicSize / 2);
       olContext.drawGeometry(new geom.Point([centerX, centerY]));
 
       // For (back)slash marks, draw extra copies to the sides to ensure complete tiling coverage when used as a pattern.
@@ -2537,14 +2588,39 @@
       var ref$1 = mark || {};
       var wellknownname = ref$1.wellknownname;
       if (wellknownname && wellknownname.indexOf('slash') > -1) {
-        olContext.drawGeometry(new geom.Point([centerX - graphicSize, centerY]));
-        olContext.drawGeometry(new geom.Point([centerX + graphicSize, centerY]));
-        olContext.drawGeometry(new geom.Point([centerX, centerY - graphicSize]));
-        olContext.drawGeometry(new geom.Point([centerX, centerY + graphicSize]));
+        olContext.drawGeometry(
+          new geom.Point([centerX - scaleFactor * graphicSize, centerY])
+        );
+        olContext.drawGeometry(
+          new geom.Point([centerX + scaleFactor * graphicSize, centerY])
+        );
+        olContext.drawGeometry(
+          new geom.Point([centerX, centerY - scaleFactor * graphicSize])
+        );
+        olContext.drawGeometry(
+          new geom.Point([centerX, centerY + scaleFactor * graphicSize])
+        );
       }
 
+      // Downscale the drawn mark back to original graphic size.
+      var patternCanvas = document.createElement('canvas');
+      patternCanvas.width = graphicSize;
+      patternCanvas.height = graphicSize;
+      var patternContext = patternCanvas.getContext('2d');
+      patternContext.drawImage(
+        scaledCanvas,
+        0,
+        0,
+        graphicSize * scaleFactor,
+        graphicSize * scaleFactor,
+        0,
+        0,
+        graphicSize,
+        graphicSize
+      );
+
       // Turn the generated image into a repeating pattern, just like a regular image fill.
-      var pattern = context.createPattern(canvas, 'repeat');
+      var pattern = patternContext.createPattern(patternCanvas, 'repeat');
       fill = new style.Fill({
         color: pattern,
       });

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -1741,7 +1741,7 @@
           angle: Math.PI / 4,
           fill: fill,
           points: 4,
-          radius1: radius,
+          radius1: Math.sqrt(2.0) * radius,
           radius2: 0,
           stroke:
             stroke ||

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -2604,19 +2604,19 @@
 
       // Downscale the drawn mark back to original graphic size.
       var patternCanvas = document.createElement('canvas');
-      patternCanvas.width = graphicSize;
-      patternCanvas.height = graphicSize;
+      patternCanvas.width = canvasSize;
+      patternCanvas.height = canvasSize;
       var patternContext = patternCanvas.getContext('2d');
       patternContext.drawImage(
         scaledCanvas,
         0,
         0,
-        graphicSize * scaleFactor,
-        graphicSize * scaleFactor,
+        canvasSize * scaleFactor,
+        canvasSize * scaleFactor,
         0,
         0,
-        graphicSize,
-        graphicSize
+        canvasSize,
+        canvasSize
       );
 
       // Turn the generated image into a repeating pattern, just like a regular image fill.

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -2493,8 +2493,26 @@
       // Note: OL rendering context size params are always in css pixels, while the temp canvas may
       // be larger depending on the device pixel ratio.
       var olContext = render.toContext(context, { size: [graphicSize, graphicSize] });
+
+      // Disable image smoothing to ensure crisp graphic fill pattern.
+      context.imageSmoothingEnabled = false;
+
+      // Let OpenLayers draw the symbol to the canvas directly.
+      // Draw extra copies to the sides to ensure complete tiling coverage when used as a pattern.
+      // S = symbol, C = copy.
+      //     +---+
+      //     | C |
+      // +---+---+---+
+      // | C | S | C |
+      // +---+---+---+
+      //     | C |
+      //     +---+
       olContext.setStyle(pointStyle);
       olContext.drawGeometry(new geom.Point([graphicSize / 2, graphicSize / 2]));
+      olContext.drawGeometry(new geom.Point([-(graphicSize / 2), graphicSize / 2]));
+      olContext.drawGeometry(new geom.Point([3 * (graphicSize / 2), graphicSize / 2]));
+      olContext.drawGeometry(new geom.Point([graphicSize / 2, -(graphicSize / 2)]));
+      olContext.drawGeometry(new geom.Point([graphicSize / 2, 3 * (graphicSize / 2)]));
 
       // Turn the generated image into a repeating pattern, just like a regular image fill.
       var pattern = context.createPattern(canvas, 'repeat');

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -1771,12 +1771,32 @@
           rotation: rotationRadians,
         });
 
+      case 'line':
+        return new style.RegularShape({
+          fill: fill,
+          points: 2,
+          radius: radius,
+          angle: 0,
+          stroke: stroke,
+          rotation: rotationRadians,
+        });
+
       case 'backslash':
         return new style.RegularShape({
           fill: fill,
           points: 2,
           radius: radius * Math.sqrt(2),
           angle: -Math.PI / 4,
+          stroke: stroke,
+          rotation: rotationRadians,
+        });
+
+      case 'slash':
+        return new style.RegularShape({
+          fill: fill,
+          points: 2,
+          radius: radius * Math.sqrt(2),
+          angle: Math.PI / 4,
           stroke: stroke,
           rotation: rotationRadians,
         });

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -2495,7 +2495,7 @@
     var ref = symbolizer.fill;
     var graphicfill = ref.graphicfill;
     var graphic = graphicfill.graphic;
-    var graphicSize = graphic.size || DEFAULT_MARK_SIZE;
+    var graphicSize = Number(graphic.size) || DEFAULT_MARK_SIZE;
     var canvasSize = graphicSize * has.DEVICE_PIXEL_RATIO;
     var fill = null;
 
@@ -2518,7 +2518,13 @@
       context.imageSmoothingEnabled = false;
 
       // Let OpenLayers draw the symbol to the canvas directly.
-      // Draw extra copies to the sides to ensure complete tiling coverage when used as a pattern.
+      olContext.setStyle(pointStyle);
+
+      var centerX = graphicSize / 2;
+      var centerY = graphicSize / 2;
+      olContext.drawGeometry(new geom.Point([centerX, centerY]));
+
+      // For (back)slash marks, draw extra copies to the sides to ensure complete tiling coverage when used as a pattern.
       // S = symbol, C = copy.
       //     +---+
       //     | C |
@@ -2527,12 +2533,15 @@
       // +---+---+---+
       //     | C |
       //     +---+
-      olContext.setStyle(pointStyle);
-      olContext.drawGeometry(new geom.Point([graphicSize / 2, graphicSize / 2]));
-      olContext.drawGeometry(new geom.Point([-(graphicSize / 2), graphicSize / 2]));
-      olContext.drawGeometry(new geom.Point([3 * (graphicSize / 2), graphicSize / 2]));
-      olContext.drawGeometry(new geom.Point([graphicSize / 2, -(graphicSize / 2)]));
-      olContext.drawGeometry(new geom.Point([graphicSize / 2, 3 * (graphicSize / 2)]));
+      var mark = graphic.mark;
+      var ref$1 = mark || {};
+      var wellknownname = ref$1.wellknownname;
+      if (wellknownname && wellknownname.indexOf('slash') > -1) {
+        olContext.drawGeometry(new geom.Point([centerX - graphicSize, centerY]));
+        olContext.drawGeometry(new geom.Point([centerX + graphicSize, centerY]));
+        olContext.drawGeometry(new geom.Point([centerX, centerY - graphicSize]));
+        olContext.drawGeometry(new geom.Point([centerX, centerY + graphicSize]));
+      }
 
       // Turn the generated image into a repeating pattern, just like a regular image fill.
       var pattern = context.createPattern(canvas, 'repeat');

--- a/src/styles/polygonStyle.js
+++ b/src/styles/polygonStyle.js
@@ -181,19 +181,19 @@ function getMarkGraphicFill(symbolizer) {
 
     // Downscale the drawn mark back to original graphic size.
     const patternCanvas = document.createElement('canvas');
-    patternCanvas.width = graphicSize;
-    patternCanvas.height = graphicSize;
+    patternCanvas.width = canvasSize;
+    patternCanvas.height = canvasSize;
     const patternContext = patternCanvas.getContext('2d');
     patternContext.drawImage(
       scaledCanvas,
       0,
       0,
-      graphicSize * scaleFactor,
-      graphicSize * scaleFactor,
+      canvasSize * scaleFactor,
+      canvasSize * scaleFactor,
       0,
       0,
-      graphicSize,
-      graphicSize
+      canvasSize,
+      canvasSize
     );
 
     // Turn the generated image into a repeating pattern, just like a regular image fill.

--- a/src/styles/polygonStyle.js
+++ b/src/styles/polygonStyle.js
@@ -91,8 +91,26 @@ function getMarkGraphicFill(symbolizer) {
     // Note: OL rendering context size params are always in css pixels, while the temp canvas may
     // be larger depending on the device pixel ratio.
     const olContext = toContext(context, { size: [graphicSize, graphicSize] });
+
+    // Disable image smoothing to ensure crisp graphic fill pattern.
+    context.imageSmoothingEnabled = false;
+
+    // Let OpenLayers draw the symbol to the canvas directly.
+    // Draw extra copies to the sides to ensure complete tiling coverage when used as a pattern.
+    // S = symbol, C = copy.
+    //     +---+
+    //     | C |
+    // +---+---+---+
+    // | C | S | C |
+    // +---+---+---+
+    //     | C |
+    //     +---+
     olContext.setStyle(pointStyle);
     olContext.drawGeometry(new Point([graphicSize / 2, graphicSize / 2]));
+    olContext.drawGeometry(new Point([-(graphicSize / 2), graphicSize / 2]));
+    olContext.drawGeometry(new Point([3 * (graphicSize / 2), graphicSize / 2]));
+    olContext.drawGeometry(new Point([graphicSize / 2, -(graphicSize / 2)]));
+    olContext.drawGeometry(new Point([graphicSize / 2, 3 * (graphicSize / 2)]));
 
     // Turn the generated image into a repeating pattern, just like a regular image fill.
     const pattern = context.createPattern(canvas, 'repeat');

--- a/src/styles/wellknown.js
+++ b/src/styles/wellknown.js
@@ -102,7 +102,7 @@ function getWellKnownSymbol(
         angle: Math.PI / 4,
         fill,
         points: 4,
-        radius1: radius,
+        radius1: Math.sqrt(2.0) * radius,
         radius2: 0,
         stroke:
           stroke ||

--- a/src/styles/wellknown.js
+++ b/src/styles/wellknown.js
@@ -132,12 +132,32 @@ function getWellKnownSymbol(
         rotation: rotationRadians,
       });
 
+    case 'line':
+      return new RegularShape({
+        fill,
+        points: 2,
+        radius,
+        angle: 0,
+        stroke,
+        rotation: rotationRadians,
+      });
+
     case 'backslash':
       return new RegularShape({
         fill,
         points: 2,
         radius: radius * Math.sqrt(2),
         angle: -Math.PI / 4,
+        stroke,
+        rotation: rotationRadians,
+      });
+
+    case 'slash':
+      return new RegularShape({
+        fill,
+        points: 2,
+        radius: radius * Math.sqrt(2),
+        angle: Math.PI / 4,
         stroke,
         rotation: rotationRadians,
       });


### PR DESCRIPTION
This PR improves the visual clarity of polygon graphic fills with mark symbols. It also adds `line` and `slash` symbolizers and extends the `x` symbolizer to cover the entire symbol square space.