### PR TITLE
Create ol style

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -6,6 +6,7 @@ nav_order: 4
 
 # Basic usage
 
+### Applying an SLD to a layer as a style function
 ```javascript
   /**
    * @param {object} vector layer
@@ -25,9 +26,9 @@ nav_order: 4
         const viewCenter = map.getView().getCenter();
         return ol.proj.getPointResolution(viewProjection, viewResolution, viewCenter);
       },
-      // If you use point icons with an ExternalGraphic, you have to use imageLoadCallback to
+      // If you use point icons with an ExternalGraphic, you have to use imageLoadCallback
       // to update the vector layer when an image finishes loading.
-      // If you do not do this, the image will only become visible after the next pan/zoom of the layer.
+      // If you do not do this, the image will only be visible after next layer pan/zoom.
       imageLoadedCallback: () => {
         vectorLayer.changed();
       },
@@ -51,6 +52,21 @@ nav_order: 4
   });
 
   applySLD(vectorLayer, mySLDString);
+```
+
+### Extracting static OpenLayers styles for a specific geometry type from an SLD rule
+```javascript
+const sldObject = SLDReader.Reader(sldXml);
+const sldLayer = SLDReader.getLayer(sldObject);
+const style = SLDReader.getStyle(sldLayer);
+const featureTypeStyle = style.featuretypestyles[0];
+
+// There can be more than one symbolizer of a given type inside a style rule,
+// therefore getOlStyle always returns an array of OpenLayers style instances.
+// Valid geometry types are 'Point', 'LineString', and 'Polygon'.
+const lineStyles = SLDReader.createOlStyle(featureTypeStyle.rules[0], 'LineString');
+
+vectorLayer.setStyle(lineStyles);
 ```
 
 {% include_relative apigen.md %}

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -3162,13 +3162,29 @@
    * @param {object|Feature} feature {@link http://geojson.org|geojson}
    *  or {@link https://openlayers.org/en/latest/apidoc/module-ol_Feature-Feature.html|ol/Feature} Changed in 0.0.04 & 0.0.5!
    * @param {Function} getProperty A property getter: (feature, propertyName) => property value.
+   * @param {object} [options] Optional options object.
+   * @param {boolean} [options.strictGeometryMatch] When true, only apply symbolizers to the corresponding geometry type.
+   * E.g. point symbolizers will not be applied to lines and polygons. Default false (according to SLD spec).
    * @return ol.style.Style or array of it
    */
-  function OlStyler(GeometryStyles, feature, getProperty) {
+  function OlStyler(
+    GeometryStyles,
+    feature,
+    getProperty,
+    options
+  ) {
+    if ( options === void 0 ) options = {};
+
     var polygon = GeometryStyles.polygon;
     var line = GeometryStyles.line;
     var point = GeometryStyles.point;
     var text = GeometryStyles.text;
+
+    var defaultOptions = {
+      strictGeometryMatch: false,
+    };
+
+    var styleOptions = Object.assign({}, defaultOptions, options);
 
     var geometry = feature.getGeometry
       ? feature.getGeometry()
@@ -3193,7 +3209,9 @@
           appendStyle(styles, line[j$2], feature, getLineStyle, getProperty);
         }
         for (var j$3 = 0; j$3 < point.length; j$3 += 1) {
-          appendStyle(styles, point[j$3], feature, getLinePointStyle, getProperty);
+          if (!styleOptions.strictGeometryMatch) {
+            appendStyle(styles, point[j$3], feature, getLinePointStyle, getProperty);
+          }
         }
         for (var j$4 = 0; j$4 < text.length; j$4 += 1) {
           styles.push(getTextStyle(text[j$4], feature, getProperty));
@@ -3206,7 +3224,9 @@
           appendStyle(styles, polygon[j$5], feature, getPolygonStyle, getProperty);
         }
         for (var j$6 = 0; j$6 < line.length; j$6 += 1) {
-          appendStyle(styles, line[j$6], feature, getLineStyle, getProperty);
+          if (!styleOptions.strictGeometryMatch) {
+            appendStyle(styles, line[j$6], feature, getLineStyle, getProperty);
+          }
         }
         for (var j$7 = 0; j$7 < point.length; j$7 += 1) {
           appendStyle(
@@ -3335,7 +3355,8 @@
     var olStyles = OlStyler(
       geometryStyles,
       { geometry: { type: geometryType } },
-      function () { return null; }
+      function () { return null; },
+      { strictGeometryMatch: true }
     );
 
     return olStyles.filter(function (style) { return style !== null; });

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -24,10 +24,16 @@ const defaultStyles = [defaultPointStyle];
 function appendStyle(styles, symbolizers, feature, styleFunction, getProperty) {
   if (Array.isArray(symbolizers)) {
     for (let k = 0; k < symbolizers.length; k += 1) {
-      styles.push(styleFunction(symbolizers[k], feature, getProperty));
+      const olStyle = styleFunction(symbolizers[k], feature, getProperty);
+      if (olStyle) {
+        styles.push(olStyle);
+      }
     }
   } else {
-    styles.push(styleFunction(symbolizers, feature, getProperty));
+    const olStyle = styleFunction(symbolizers, feature, getProperty);
+    if (olStyle) {
+      styles.push(olStyle);
+    }
   }
 }
 
@@ -187,4 +193,27 @@ export function createOlStyleFunction(featureTypeStyle, options = {}) {
 
     return olStyles;
   };
+}
+
+/**
+ * Create an array of OpenLayers style instances for features with the chosen geometry type from a style rule.
+ * Since this function creates a static OpenLayers style and not a style function,
+ * usage of this function is only suitable for simple symbolizers that do not depend on feature properties
+ * and do not contain external graphics. External graphic marks will be shown as a grey circle instead.
+ * @param {StyleRule} styleRule Feature Type Style Rule object.
+ * @param {string} geometryType One of 'Point', 'LineString' or 'Polygon'
+ * @returns {Array<ol.Style>} An array of OpenLayers style instances.
+ * @example
+ * myOlVectorLayer.setStyle(SLDReader.createOlStyle(featureTypeStyle.rules[0], 'Point');
+ */
+export function createOlStyle(styleRule, geometryType) {
+  const geometryStyles = getGeometryStyles([styleRule]);
+
+  const olStyles = OlStyler(
+    geometryStyles,
+    { geometry: { type: geometryType } },
+    () => null
+  );
+
+  return olStyles.filter(style => style !== null);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,12 @@
 import Reader from './Reader';
-import OlStyler, { createOlStyleFunction } from './OlStyler';
+import OlStyler, { createOlStyleFunction, createOlStyle } from './OlStyler';
 import getGeometryStyles from './GeometryStyles';
 
 export * from './Utils';
-export { Reader, getGeometryStyles, OlStyler, createOlStyleFunction };
+export {
+  Reader,
+  getGeometryStyles,
+  OlStyler,
+  createOlStyleFunction,
+  createOlStyle,
+};

--- a/src/styles/linePointStyle.js
+++ b/src/styles/linePointStyle.js
@@ -27,6 +27,10 @@ function getLineMidpoint(geometry) {
  * @returns {ol/Style} OpenLayers style instance.
  */
 function getLinePointStyle(symbolizer, feature) {
+  if (typeof feature.getGeometry !== 'function') {
+    return null;
+  }
+
   const geom = feature.getGeometry();
   if (!geom) {
     return null;

--- a/src/styles/polygonPointStyle.js
+++ b/src/styles/polygonPointStyle.js
@@ -23,6 +23,10 @@ function getInteriorPoint(geometry) {
  * @returns {ol/Style} OpenLayers style instance.
  */
 function getPolygonPointStyle(symbolizer, feature) {
+  if (typeof feature.getGeometry !== 'function') {
+    return null;
+  }
+
   const geom = feature.getGeometry();
   if (!geom) {
     return null;

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -917,15 +917,22 @@ describe('Static style extraction with getOlStyle', () => {
     expect(lineStyle.getStroke().getWidth()).to.equal(1);
   });
 
-  it('Does not crash when trying to extract a line style from a point symbolizer SLD', () => {
+  it('Does not extract a line style from a point symbolizer', () => {
     const sldObject = Reader(simplePointSymbolizerSld);
     const [featureTypeStyle] = sldObject.layers[0].styles[0].featuretypestyles;
     const olStyles = createOlStyle(featureTypeStyle.rules[0], 'LineString');
     expect(olStyles.length).to.equal(0);
   });
 
-  it('Does not crash when trying to extract a polygon style from a point symbolizer SLD', () => {
+  it('Does not extract a polygon style from a point symbolizer', () => {
     const sldObject = Reader(simplePointSymbolizerSld);
+    const [featureTypeStyle] = sldObject.layers[0].styles[0].featuretypestyles;
+    const olStyles = createOlStyle(featureTypeStyle.rules[0], 'Polygon');
+    expect(olStyles.length).to.equal(0);
+  });
+
+  it('Does not extract a polygon style from a line symbolizer', () => {
+    const sldObject = Reader(simpleLineSymbolizerSld);
     const [featureTypeStyle] = sldObject.layers[0].styles[0].featuretypestyles;
     const olStyles = createOlStyle(featureTypeStyle.rules[0], 'Polygon');
     expect(olStyles.length).to.equal(0);

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -3,7 +3,10 @@ import { Style, Circle } from 'ol/style';
 import OLFormatGeoJSON from 'ol/format/GeoJSON';
 
 import Reader from '../src/Reader';
-import OlStyler, { createOlStyleFunction } from '../src/OlStyler';
+import OlStyler, {
+  createOlStyle,
+  createOlStyleFunction,
+} from '../src/OlStyler';
 
 import { sld } from './data/test.sld';
 import { sld11 } from './data/test11.sld';
@@ -900,5 +903,31 @@ describe('PointSymbolizer and mixed geometries', () => {
     let style = styleFunction(lineFeature)[0];
     style = styleFunction(pointFeature)[0];
     expect(style.getGeometry()).to.be.null;
+  });
+});
+
+describe('Static style extraction with getOlStyle', () => {
+  it('Extract line symbolizer style from SLD rule', () => {
+    const sldObject = Reader(simpleLineSymbolizerSld);
+    const [featureTypeStyle] = sldObject.layers[0].styles[0].featuretypestyles;
+    const olStyles = createOlStyle(featureTypeStyle.rules[0], 'LineString');
+    expect(olStyles.length).to.equal(1);
+    const [lineStyle] = olStyles;
+    expect(lineStyle.getStroke().getColor()).to.equal('#FF0000');
+    expect(lineStyle.getStroke().getWidth()).to.equal(1);
+  });
+
+  it('Does not crash when trying to extract a line style from a point symbolizer SLD', () => {
+    const sldObject = Reader(simplePointSymbolizerSld);
+    const [featureTypeStyle] = sldObject.layers[0].styles[0].featuretypestyles;
+    const olStyles = createOlStyle(featureTypeStyle.rules[0], 'LineString');
+    expect(olStyles.length).to.equal(0);
+  });
+
+  it('Does not crash when trying to extract a polygon style from a point symbolizer SLD', () => {
+    const sldObject = Reader(simplePointSymbolizerSld);
+    const [featureTypeStyle] = sldObject.layers[0].styles[0].featuretypestyles;
+    const olStyles = createOlStyle(featureTypeStyle.rules[0], 'Polygon');
+    expect(olStyles.length).to.equal(0);
   });
 });


### PR DESCRIPTION
Add a new function `createOlStyle` to turn a single symbolizer in a rule into a static OpenLayers style array.