### PR TITLE
Rework data stuctures

### DIFF
--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -353,13 +353,15 @@
    * @param {object} [options] Parse options.
    * @param {object} [options.skipEmptyNodes] Default true. If true, emtpy (whitespace-only) text nodes will me omitted in the result.
    * @param {object} [options.forceLowerCase] Default true. If true, convert prop name to lower case before adding it to obj.
+   * @param {object} [options.typeHint] Default 'string'. When set to 'number', a simple literal value will be converted to a number.
    */
-  function addFilterExpressionProp(node, obj, prop, options) {
+  function addParameterValueProp(node, obj, prop, options) {
     if ( options === void 0 ) options = {};
 
     var defaultParseOptions = {
       skipEmptyNodes: true,
       forceLowerCase: true,
+      typeHint: 'string',
     };
 
     var parseOptions = Object.assign({}, defaultParseOptions,
@@ -407,12 +409,22 @@
       obj[propertyName] = childExpressions
         .map(function (expression) { return expression.value; })
         .join('');
+      if (parseOptions.typeHint === 'number') {
+        obj[propertyName] = parseFloat(obj[propertyName]);
+      }
     } else {
       obj[propertyName] = {
         type: 'expression',
+        typeHint: parseOptions.typeHint,
         children: childExpressions,
       };
     }
+  }
+
+  function addNumericParameterValueProp(node, obj, prop, options) {
+    if ( options === void 0 ) options = {};
+
+    addParameterValueProp(node, obj, prop, Object.assign({}, options, {typeHint: 'number'}));
   }
 
   /**
@@ -447,7 +459,7 @@
       .getAttribute('name')
       .toLowerCase()
       .replace(/-(.)/g, function (match, group1) { return group1.toUpperCase(); });
-    addFilterExpressionProp(element, obj[parameterGroup], name, {
+    addParameterValueProp(element, obj[parameterGroup], name, {
       skipEmptyNodes: true,
       forceLowerCase: false,
     });
@@ -473,27 +485,28 @@
     GraphicFill: addProp,
     Graphic: addProp,
     ExternalGraphic: addProp,
-    Gap: addNumericProp,
-    InitialGap: addNumericProp,
+    Gap: addNumericParameterValueProp,
+    InitialGap: addNumericParameterValueProp,
     Mark: addProp,
-    Label: function (node, obj, prop) { return addFilterExpressionProp(node, obj, prop, { skipEmptyNodes: false }); },
+    Label: function (node, obj, prop) { return addParameterValueProp(node, obj, prop, { skipEmptyNodes: false }); },
     Halo: addProp,
     Font: addProp,
-    Radius: addPropWithTextContent,
+    Radius: addNumericParameterValueProp,
     LabelPlacement: addProp,
     PointPlacement: addProp,
     LinePlacement: addProp,
-    PerpendicularOffset: addPropWithTextContent,
+    PerpendicularOffset: addNumericParameterValueProp,
     AnchorPoint: addProp,
-    AnchorPointX: addPropWithTextContent,
-    AnchorPointY: addPropWithTextContent,
-    Opacity: addFilterExpressionProp,
-    Rotation: addFilterExpressionProp,
+    AnchorPointX: addNumericParameterValueProp,
+    AnchorPointY: addNumericParameterValueProp,
+    Opacity: addNumericParameterValueProp,
+    Rotation: addNumericParameterValueProp,
     Displacement: addProp,
-    DisplacementX: addPropWithTextContent,
-    DisplacementY: addPropWithTextContent,
-    Size: addFilterExpressionProp,
+    DisplacementX: addNumericParameterValueProp,
+    DisplacementY: addNumericParameterValueProp,
+    Size: addNumericParameterValueProp,
     WellKnownName: addPropWithTextContent,
+    MarkIndex: addNumericProp,
     VendorOption: function (element, obj, prop) { return addParameterValue(element, obj, prop, 'vendoroptions'); },
     OnlineResource: function (element, obj) {
       obj.onlineresource = element.getAttribute('xlink:href');

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -3389,8 +3389,6 @@
   function createOlStyleFunction(featureTypeStyle, options) {
     if ( options === void 0 ) options = {};
 
-    console.log('FTS --> ', featureTypeStyle);
-
     var imageLoadedCallback = options.imageLoadedCallback || (function () {});
 
     // Keep track of whether a callback has been registered per image url.

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -344,12 +344,14 @@
     }
 
     // Replace each literal expression with its value.
-    var simplifiedExpressions = expressions.map(function (expression) {
-      if (expression.type === 'literal') {
-        return expression.value;
-      }
-      return expression;
-    });
+    var simplifiedExpressions = expressions
+      .map(function (expression) {
+        if (expression.type === 'literal') {
+          return expression.value;
+        }
+        return expression;
+      })
+      .filter(function (expression) { return expression !== ''; });
 
     // If expression children are all literals, concatenate them into a string.
     var allLiteral = simplifiedExpressions.every(

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -267,6 +267,12 @@
    * @module
    */
 
+  var numericSvgProps = new Set([
+    'strokeWidth',
+    'strokeOpacity',
+    'strokeDashOffset',
+    'fillOpacity' ]);
+
   /**
    * Generic parser for elements with maxOccurs > 1
    * it pushes result of readNode(node) to array on obj[prop]
@@ -502,9 +508,19 @@
       .getAttribute('name')
       .toLowerCase()
       .replace(/-(.)/g, function (match, group1) { return group1.toUpperCase(); });
+
+    // Flag certain SVG parameters as numeric.
+    var typeHint = 'string';
+    if (parameterGroup === 'styling') {
+      if (numericSvgProps.has(name)) {
+        typeHint = 'number';
+      }
+    }
+
     addParameterValueProp(element, obj[parameterGroup], name, {
       skipEmptyNodes: true,
       forceLowerCase: false,
+      typeHint: typeHint,
     });
   }
 

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -538,8 +538,8 @@
     Name: addPropWithTextContent,
     Title: addPropWithTextContent,
     Abstract: addPropWithTextContent,
-    MaxScaleDenominator: addPropWithTextContent,
-    MinScaleDenominator: addPropWithTextContent},
+    MaxScaleDenominator: addNumericProp,
+    MinScaleDenominator: addNumericProp},
     FilterParsers,
     SymbParsers);
 

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -430,19 +430,13 @@
    * @param  {object} obj
    * @param  {String} prop
    */
-  function parameters(element, obj, prop) {
-    var propnames = {
-      CssParameter: 'styling',
-      SvgParameter: 'styling',
-      VendorOption: 'vendoroption',
-    };
-    var propname = propnames[prop] || 'styling';
-    obj[propname] = obj[propname] || {};
+  function addParameterValue(element, obj, prop, parameterGroup) {
+    obj[parameterGroup] = obj[parameterGroup] || {};
     var name = element
       .getAttribute('name')
       .toLowerCase()
       .replace(/-(.)/g, function (match, group1) { return group1.toUpperCase(); });
-    obj[propname][name] = element.textContent.trim();
+    obj[parameterGroup][name] = element.textContent.trim();
   }
 
   var FilterParsers = {
@@ -486,12 +480,12 @@
     DisplacementY: addPropWithTextContent,
     Size: addFilterExpressionProp,
     WellKnownName: addPropWithTextContent,
-    VendorOption: parameters,
+    VendorOption: function (element, obj, prop) { return addParameterValue(element, obj, prop, 'vendoroptions'); },
     OnlineResource: function (element, obj) {
       obj.onlineresource = element.getAttribute('xlink:href');
     },
-    CssParameter: parameters,
-    SvgParameter: parameters,
+    CssParameter: function (element, obj, prop) { return addParameterValue(element, obj, prop, 'styling'); },
+    SvgParameter: function (element, obj, prop) { return addParameterValue(element, obj, prop, 'styling'); },
   };
 
   /**
@@ -2294,10 +2288,10 @@
     };
 
     // QGIS vendor options to override graphicstroke symbol placement.
-    if (linesymbolizer.vendoroption) {
-      if (linesymbolizer.vendoroption.placement === 'firstPoint') {
+    if (linesymbolizer.vendoroptions) {
+      if (linesymbolizer.vendoroptions.placement === 'firstPoint') {
         options.placement = PLACEMENT_FIRSTPOINT;
-      } else if (linesymbolizer.vendoroption.placement === 'lastPoint') {
+      } else if (linesymbolizer.vendoroptions.placement === 'lastPoint') {
         options.placement = PLACEMENT_LASTPOINT;
       }
     }
@@ -3267,6 +3261,8 @@
    */
   function createOlStyleFunction(featureTypeStyle, options) {
     if ( options === void 0 ) options = {};
+
+    console.log('FTS --> ', featureTypeStyle);
 
     var imageLoadedCallback = options.imageLoadedCallback || (function () {});
 

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -184,8 +184,6 @@ function getOlFeatureProperty(feature, propertyName) {
  * }));
  */
 export function createOlStyleFunction(featureTypeStyle, options = {}) {
-  console.log('FTS --> ', featureTypeStyle);
-
   const imageLoadedCallback = options.imageLoadedCallback || (() => {});
 
   // Keep track of whether a callback has been registered per image url.

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -184,6 +184,8 @@ function getOlFeatureProperty(feature, propertyName) {
  * }));
  */
 export function createOlStyleFunction(featureTypeStyle, options = {}) {
+  console.log('FTS --> ', featureTypeStyle);
+
   const imageLoadedCallback = options.imageLoadedCallback || (() => {});
 
   // Keep track of whether a callback has been registered per image url.

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -4,6 +4,13 @@ import createFilter from './filter';
  * @module
  */
 
+const numericSvgProps = new Set([
+  'strokeWidth',
+  'strokeOpacity',
+  'strokeDashOffset',
+  'fillOpacity',
+]);
+
 /**
  * Generic parser for elements with maxOccurs > 1
  * it pushes result of readNode(node) to array on obj[prop]
@@ -235,9 +242,19 @@ function addParameterValue(element, obj, prop, parameterGroup) {
     .getAttribute('name')
     .toLowerCase()
     .replace(/-(.)/g, (match, group1) => group1.toUpperCase());
+
+  // Flag certain SVG parameters as numeric.
+  let typeHint = 'string';
+  if (parameterGroup === 'styling') {
+    if (numericSvgProps.has(name)) {
+      typeHint = 'number';
+    }
+  }
+
   addParameterValueProp(element, obj[parameterGroup], name, {
     skipEmptyNodes: true,
     forceLowerCase: false,
+    typeHint,
   });
 }
 

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -79,12 +79,14 @@ function simplifyChildExpressions(expressions, typeHint) {
   }
 
   // Replace each literal expression with its value.
-  const simplifiedExpressions = expressions.map(expression => {
-    if (expression.type === 'literal') {
-      return expression.value;
-    }
-    return expression;
-  });
+  const simplifiedExpressions = expressions
+    .map(expression => {
+      if (expression.type === 'literal') {
+        return expression.value;
+      }
+      return expression;
+    })
+    .filter(expression => expression !== '');
 
   // If expression children are all literals, concatenate them into a string.
   const allLiteral = simplifiedExpressions.every(

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -163,19 +163,13 @@ function getBool(element, tagName) {
  * @param  {object} obj
  * @param  {String} prop
  */
-function parameters(element, obj, prop) {
-  const propnames = {
-    CssParameter: 'styling',
-    SvgParameter: 'styling',
-    VendorOption: 'vendoroption',
-  };
-  const propname = propnames[prop] || 'styling';
-  obj[propname] = obj[propname] || {};
+function addParameterValue(element, obj, prop, parameterGroup) {
+  obj[parameterGroup] = obj[parameterGroup] || {};
   const name = element
     .getAttribute('name')
     .toLowerCase()
     .replace(/-(.)/g, (match, group1) => group1.toUpperCase());
-  obj[propname][name] = element.textContent.trim();
+  obj[parameterGroup][name] = element.textContent.trim();
 }
 
 const FilterParsers = {
@@ -219,12 +213,15 @@ const SymbParsers = {
   DisplacementY: addPropWithTextContent,
   Size: addFilterExpressionProp,
   WellKnownName: addPropWithTextContent,
-  VendorOption: parameters,
+  VendorOption: (element, obj, prop) =>
+    addParameterValue(element, obj, prop, 'vendoroptions'),
   OnlineResource: (element, obj) => {
     obj.onlineresource = element.getAttribute('xlink:href');
   },
-  CssParameter: parameters,
-  SvgParameter: parameters,
+  CssParameter: (element, obj, prop) =>
+    addParameterValue(element, obj, prop, 'styling'),
+  SvgParameter: (element, obj, prop) =>
+    addParameterValue(element, obj, prop, 'styling'),
 };
 
 /**

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -278,8 +278,8 @@ const parsers = {
   Name: addPropWithTextContent,
   Title: addPropWithTextContent,
   Abstract: addPropWithTextContent,
-  MaxScaleDenominator: addPropWithTextContent,
-  MinScaleDenominator: addPropWithTextContent,
+  MaxScaleDenominator: addNumericProp,
+  MinScaleDenominator: addNumericProp,
   ...FilterParsers,
   ...SymbParsers,
 };

--- a/src/styles/graphicStrokeStyle.js
+++ b/src/styles/graphicStrokeStyle.js
@@ -132,10 +132,10 @@ export function getGraphicStrokeRenderer(linesymbolizer, getProperty) {
   };
 
   // QGIS vendor options to override graphicstroke symbol placement.
-  if (linesymbolizer.vendoroption) {
-    if (linesymbolizer.vendoroption.placement === 'firstPoint') {
+  if (linesymbolizer.vendoroptions) {
+    if (linesymbolizer.vendoroptions.placement === 'firstPoint') {
       options.placement = PLACEMENT_FIRSTPOINT;
-    } else if (linesymbolizer.vendoroption.placement === 'lastPoint') {
+    } else if (linesymbolizer.vendoroptions.placement === 'lastPoint') {
       options.placement = PLACEMENT_LASTPOINT;
     }
   }

--- a/src/styles/pointStyle.js
+++ b/src/styles/pointStyle.js
@@ -14,7 +14,7 @@ import {
 } from './static';
 import { createCachedImageStyle, getImageLoadingState } from '../imageCache';
 import getWellKnownSymbol from './wellknown';
-import evaluate, { expressionOrDefault } from '../olEvaluator';
+import evaluate, { expressionOrDefault, isDynamicExpression } from '../olEvaluator';
 import { getSimpleFill, getSimpleStroke } from './simpleStyles';
 
 const defaultMarkFill = getSimpleFill({ styling: { fill: '#888888' } });
@@ -119,7 +119,7 @@ function getPointStyle(symbolizer, feature, getProperty) {
   // --- Update dynamic size ---
   const { graphic } = symbolizer;
   const { size } = graphic;
-  if (size && size.type === 'expression') {
+  if (isDynamicExpression(size)) {
     const sizeValue =
       Number(evaluate(size, feature, getProperty)) || DEFAULT_MARK_SIZE;
 
@@ -145,7 +145,7 @@ function getPointStyle(symbolizer, feature, getProperty) {
 
   // --- Update dynamic rotation ---
   const { rotation } = graphic;
-  if (rotation && rotation.type === 'expression') {
+  if (isDynamicExpression(rotation)) {
     const rotationDegrees =
       Number(evaluate(rotation, feature, getProperty)) || 0.0;
     // Note: OL angles are in radians.

--- a/src/styles/textStyle.js
+++ b/src/styles/textStyle.js
@@ -1,6 +1,9 @@
 import { Style, Fill, Stroke, Text } from 'ol/style';
 import { hexToRGB, memoizeStyleFunction } from './styleUtils';
-import evaluate, { expressionOrDefault } from '../olEvaluator';
+import evaluate, {
+  expressionOrDefault,
+  isDynamicExpression,
+} from '../olEvaluator';
 import { emptyStyle } from './static';
 
 /**
@@ -138,7 +141,7 @@ function getTextStyle(symbolizer, feature, getProperty) {
   const { label, labelplacement } = symbolizer;
 
   // Set text only if the label expression is dynamic.
-  if (label && label.type === 'expression') {
+  if (isDynamicExpression(label)) {
     const labelText = evaluate(label, feature, getProperty);
     // Important! OpenLayers expects the text property to always be a string.
     olText.setText(labelText.toString());
@@ -150,7 +153,7 @@ function getTextStyle(symbolizer, feature, getProperty) {
       (labelplacement.pointplacement &&
         labelplacement.pointplacement.rotation) ||
       0.0;
-    if (pointPlacementRotation.type === 'expression') {
+    if (isDynamicExpression(pointPlacementRotation)) {
       const labelRotationDegrees = evaluate(
         pointPlacementRotation,
         feature,

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -366,14 +366,14 @@ describe('Parse vendor options', () => {
     [style] = parsedSld.layers[0].styles[0].featuretypestyles;
   });
 
-  it('Sections without vendor options have no .vendoroption prop', () => {
+  it('Sections without vendor options have no .vendoroptions prop', () => {
     const symbolizer = style.rules[0].linesymbolizer[0];
-    expect(symbolizer.vendoroption).to.be.undefined;
+    expect(symbolizer.vendoroptions).to.be.undefined;
   });
 
-  it('Parse vendor options into a .vendoroption prop', () => {
+  it('Parse vendor options into a .vendoroptions prop', () => {
     const symbolizer = style.rules[0].linesymbolizer[1];
-    expect(symbolizer.vendoroption).to.deep.equal({
+    expect(symbolizer.vendoroptions).to.deep.equal({
       placement: 'lastPoint',
     });
   });

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -207,6 +207,7 @@ describe('Dynamic filter expressions', () => {
     const rule = featureTypeStyle.rules[0];
     expect(rule.pointsymbolizer[0].graphic.size).to.deep.equal({
       type: 'expression',
+      typeHint: 'number',
       children: [
         {
           type: 'propertyname',
@@ -275,9 +276,9 @@ describe('Graphicstroke symbolizer', () => {
     expect(stroke.graphicstroke.graphic).to.be.an.instanceof(Object);
     expect(stroke.graphicstroke.graphic).to.have.property('mark');
     expect(stroke.graphicstroke.graphic).to.have.property('size');
-    expect(stroke.graphicstroke.graphic.size).to.equal('4');
+    expect(stroke.graphicstroke.graphic.size).to.equal(4);
     expect(stroke.graphicstroke.graphic).to.have.property('rotation');
-    expect(stroke.graphicstroke.graphic.rotation).to.equal('45');
+    expect(stroke.graphicstroke.graphic.rotation).to.equal(45);
     expect(stroke.graphicstroke.graphic.mark).to.have.property('wellknownname');
     expect(stroke.graphicstroke.graphic.mark.wellknownname).to.equal('square');
     expect(stroke.graphicstroke.graphic.mark).to.have.property('fill');

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -6,7 +6,9 @@ import { dynamicSld } from './data/dynamic.sld';
 import { graphicstrokeSymbolizerSld } from './data/graphicstrokeSymbolizer.sld';
 import { graphicStrokeWithGap } from './data/graphicstroke-with-gap.sld';
 import { multipleSymbolizersSld } from './data/multiple-symbolizers.sld';
-import graphicStrokeVendorOption from './data/graphicstroke-vendoroption.sld';
+import { staticPolygonSymbolizerSld } from './data/static-polygon-symbolizer.sld';
+import { dynamicPolygonSymbolizerSld } from './data/dynamic-polygon-symbolizer.sld';
+import { graphicStrokeVendorOption } from './data/graphicstroke-vendoroption.sld';
 
 let result;
 
@@ -49,7 +51,7 @@ describe('Reads xml', () => {
     expect(symbolizer.fill).to.be.an.instanceof(Object);
     expect(symbolizer.fill.styling).to.be.an.instanceof(Object);
     expect(symbolizer.fill.styling.fill).to.equal('blue');
-    expect(symbolizer.fill.styling.fillOpacity).to.equal('1.0');
+    expect(symbolizer.fill.styling.fillOpacity).to.equal(1.0);
     expect(symbolizer.stroke.styling.stroke).to.equal('#C0C0C0');
   });
   it('Scale denominators are numeric', () => {
@@ -251,7 +253,7 @@ describe('Graphicstroke symbolizer', () => {
     expect(linesymbolizer1.stroke).to.be.an.instanceof(Object);
     expect(linesymbolizer1.stroke.styling).to.be.an.instanceof(Object);
     expect(linesymbolizer1.stroke.styling.stroke).to.equal('#FF0000');
-    expect(linesymbolizer1.stroke.styling.strokeWidth).to.equal('1');
+    expect(linesymbolizer1.stroke.styling.strokeWidth).to.equal(1);
   });
   it('rule linesymbolizer has props from svg 2', () => {
     const linesymbolizer2 =
@@ -286,7 +288,7 @@ describe('Graphicstroke symbolizer', () => {
       'fillOpacity'
     );
     expect(stroke.graphicstroke.graphic.mark.fill.styling.fillOpacity).to.equal(
-      '1'
+      1.0
     );
     expect(stroke.graphicstroke.graphic.mark).to.have.property('stroke');
     expect(stroke.graphicstroke.graphic.mark.stroke).to.have.property(
@@ -303,13 +305,13 @@ describe('Graphicstroke symbolizer', () => {
     );
     expect(
       stroke.graphicstroke.graphic.mark.stroke.styling.strokeWidth
-    ).to.equal('1');
+    ).to.equal(1);
     expect(stroke.graphicstroke.graphic.mark.stroke.styling).to.have.property(
       'strokeOpacity'
     );
     expect(
       stroke.graphicstroke.graphic.mark.stroke.styling.strokeOpacity
-    ).to.equal('1');
+    ).to.equal(1.0);
   });
 });
 
@@ -340,7 +342,7 @@ describe('SLD v1.1.0 GraphicStroke properties', () => {
     const { stroke } = graphicStroke.graphic.mark;
     expect(stroke.styling).to.deep.equal({
       stroke: '#232323',
-      strokeWidth: '0.5',
+      strokeWidth: 0.5,
     });
   });
 
@@ -415,5 +417,77 @@ describe('Symbolizers are always an array', () => {
 
   it('Multiple Polygon symbolizers --> array', () => {
     expect(Array.isArray(style.rules[7].polygonsymbolizer)).to.be.true;
+  });
+});
+
+describe('SVG style parameters', () => {
+  describe('Static SVG parameters', () => {
+    let style;
+    let fillStyle;
+    let strokeStyle;
+    beforeEach(() => {
+      const parsedSld = Reader(staticPolygonSymbolizerSld);
+      [style] = parsedSld.layers[0].styles[0].featuretypestyles;
+      const stroke = style.rules[0].polygonsymbolizer[0].stroke;
+      strokeStyle = stroke.styling;
+      const fill = style.rules[0].polygonsymbolizer[0].fill;
+      fillStyle = fill.styling;
+    });
+
+    it('Fill color should be string', () => {
+      expect(fillStyle.fill).to.equal('#FF0000');
+    });
+    it('Fill opacity should be number', () => {
+      expect(fillStyle.fillOpacity).to.equal(0.5);
+    });
+    it('Stroke color should be string', () => {
+      expect(strokeStyle.stroke).to.equal('#00FF00');
+    });
+    it('Stroke opacity should be number', () => {
+      expect(strokeStyle.strokeOpacity).to.equal(1.0);
+    });
+    it('Stroke width should be number', () => {
+      expect(strokeStyle.strokeWidth).to.equal(4);
+    });
+  });
+
+  describe('Dynamic SVG parameters', () => {
+    let style;
+    let fillStyle;
+    let strokeStyle;
+    beforeEach(() => {
+      const parsedSld = Reader(dynamicPolygonSymbolizerSld);
+      [style] = parsedSld.layers[0].styles[0].featuretypestyles;
+      const stroke = style.rules[0].polygonsymbolizer[0].stroke;
+      strokeStyle = stroke.styling;
+      const fill = style.rules[0].polygonsymbolizer[0].fill;
+      fillStyle = fill.styling;
+    });
+
+    // Check stroke width dynamic style value.
+    it('Dynamic style property should be a propertyname expression', () => {
+      expect(strokeStyle.strokeWidth).to.deep.equal({
+        type: 'propertyname',
+        value: 'myStrokeWidth',
+        typeHint: 'number',
+      });
+    });
+
+    // Check types of possible SVG parameters.
+    it('Fill color should be string', () => {
+      expect(fillStyle.fill.typeHint).to.equal('string');
+    });
+    it('Fill opacity should be number', () => {
+      expect(fillStyle.fillOpacity.typeHint).to.equal('number');
+    });
+    it('Stroke color should be string', () => {
+      expect(strokeStyle.stroke.typeHint).to.equal('string');
+    });
+    it('Stroke opacity should be number', () => {
+      expect(strokeStyle.strokeOpacity.typeHint).to.equal('number');
+    });
+    it('Stroke width should be number', () => {
+      expect(strokeStyle.strokeWidth.typeHint).to.equal('number');
+    });
   });
 });

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -170,13 +170,11 @@ describe('Reads xml sld 11', () => {
       result.layers['0'].styles['0'].featuretypestyles['0'].rules['3'];
     const [symbolizer] = rule.textsymbolizer;
     expect(symbolizer).to.be.an.instanceof(Object);
-    expect(symbolizer.label).to.be.an.instanceof(Object);
-    expect(symbolizer.label.type).to.equal('expression');
-    expect(
-      symbolizer.label.children.some(
-        l => l.type === 'propertyname' && l.value === 'provincienaam'
-      )
-    ).to.be.true;
+    expect(symbolizer.label).to.deep.equal({
+      type: 'propertyname',
+      typeHint: 'string',
+      value: 'provincienaam',
+    });
   });
   it('rule textsymbolizer has font', () => {
     const rule =

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -206,14 +206,9 @@ describe('Dynamic filter expressions', () => {
   it('Has propertyname expression for size', () => {
     const rule = featureTypeStyle.rules[0];
     expect(rule.pointsymbolizer[0].graphic.size).to.deep.equal({
-      type: 'expression',
+      type: 'propertyname',
       typeHint: 'number',
-      children: [
-        {
-          type: 'propertyname',
-          value: 'size',
-        },
-      ],
+      value: 'size',
     });
   });
 });

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -45,13 +45,18 @@ describe('Reads xml', () => {
     const rule =
       result.layers['0'].styles['0'].featuretypestyles['0'].rules['0'];
     const [symbolizer] = rule.polygonsymbolizer;
-    expect(rule.maxscaledenominator).to.equal('3000000');
     expect(symbolizer).to.be.an.instanceof(Object);
     expect(symbolizer.fill).to.be.an.instanceof(Object);
     expect(symbolizer.fill.styling).to.be.an.instanceof(Object);
     expect(symbolizer.fill.styling.fill).to.equal('blue');
     expect(symbolizer.fill.styling.fillOpacity).to.equal('1.0');
     expect(symbolizer.stroke.styling.stroke).to.equal('#C0C0C0');
+  });
+  it('Scale denominators are numeric', () => {
+    const rule =
+      result.layers['0'].styles['0'].featuretypestyles['0'].rules['0'];
+    expect(rule.maxscaledenominator).to.equal(3000000);
+    expect(rule.minscaledenominator).to.equal(1000);
   });
   it('cities layer has PointSymbolizer with external graphic', () => {
     const rule =

--- a/test/data/dynamic-polygon-symbolizer.sld.js
+++ b/test/data/dynamic-polygon-symbolizer.sld.js
@@ -1,0 +1,38 @@
+export const dynamicPolygonSymbolizerSld = `<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd"
+  xmlns:se="http://www.opengis.net/se">
+  <NamedLayer>
+    <UserStyle>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:PolygonSymbolizer>
+            <se:Fill>
+              <se:SvgParameter name="fill">
+                <ogc:PropertyName>myFillColor</ogc:PropertyName>
+              </se:SvgParameter>
+              <se:SvgParameter name="fill-opacity">
+                <ogc:PropertyName>myFillOpacity</ogc:PropertyName>
+              </se:SvgParameter>
+            </se:Fill>
+            <se:Stroke>
+              <se:SvgParameter name="stroke">
+                <ogc:PropertyName>myStrokeColor</ogc:PropertyName>
+              </se:SvgParameter>
+              <se:SvgParameter name="stroke-opacity">
+                <ogc:PropertyName>myStrokeOpacity</ogc:PropertyName>
+              </se:SvgParameter>
+              <se:SvgParameter name="stroke-width">
+                <ogc:PropertyName>myStrokeWidth</ogc:PropertyName>
+              </se:SvgParameter>
+            </se:Stroke>
+          </se:PolygonSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>`;
+
+export default dynamicPolygonSymbolizerSld;

--- a/test/data/graphicstroke-vendoroption.sld.js
+++ b/test/data/graphicstroke-vendoroption.sld.js
@@ -1,4 +1,4 @@
-const graphicStrokeVendorOption = `<?xml version="1.0" encoding="UTF-8"?>
+export const graphicStrokeVendorOption = `<?xml version="1.0" encoding="UTF-8"?>
 <StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
   xmlns:ogc="http://www.opengis.net/ogc"
   xmlns:xlink="http://www.w3.org/1999/xlink"

--- a/test/data/static-polygon-symbolizer.sld.js
+++ b/test/data/static-polygon-symbolizer.sld.js
@@ -1,0 +1,28 @@
+export const staticPolygonSymbolizerSld = `<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd"
+  xmlns:se="http://www.opengis.net/se">
+  <NamedLayer>
+    <UserStyle>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:PolygonSymbolizer>
+            <se:Fill>
+              <se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+              <se:SvgParameter name="fill-opacity">0.5</se:SvgParameter>
+            </se:Fill>
+            <se:Stroke>
+              <se:SvgParameter name="stroke">#00FF00</se:SvgParameter>
+              <se:SvgParameter name="stroke-opacity">1.0</se:SvgParameter>
+              <se:SvgParameter name="stroke-width">4</se:SvgParameter>
+            </se:Stroke>
+          </se:PolygonSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>`;
+
+export default staticPolygonSymbolizerSld;

--- a/test/data/test.sld.js
+++ b/test/data/test.sld.js
@@ -28,6 +28,7 @@ export const sld = `<?xml version="1.0" encoding="UTF-8"?>
             <ogc:FeatureId fid="tasmania_water_bodies.3" />
           </ogc:Filter>
           <sld:MaxScaleDenominator>3000000</sld:MaxScaleDenominator>
+          <sld:MinScaleDenominator>1000</sld:MinScaleDenominator>
           <sld:PolygonSymbolizer>
             <sld:Fill>
               <sld:CssParameter name="fill">blue</sld:CssParameter>


### PR DESCRIPTION
A big refactoring of SLD parsing code and the corresponding SLD object data structure.

Main changes:
* Added type hints for values, so numeric properties will be marked as such.
* Simplified expression objects -> expressions with one child will be replaced with the child expression. Expressions that do not depend on feature properties will be simplified as much as possible.
* SVGParameters can be dynamic (type: 'propertyname') (support in ol styler function follows later).