### PR TITLE
Dynamic symbolizer values

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Only one Graphic per PointSymbolizer is supported. Each Graphic can only have on
 
 #### LineSymbolizer
 
-Only these static css-parameters are supported:
+Only these svg-parameters are supported:
 
 - stroke
 - stroke-width
@@ -60,6 +60,7 @@ Only these static css-parameters are supported:
 - stroke-dashoffset
 
 GraphicStroke with Mark or ExternalGraphic is mostly supported.
+
 GraphicFill and PerpendicularOffset are not supported.
 
 #### Note about GraphicStroke
@@ -74,7 +75,7 @@ ExternalGraphic is mostly supported with these caveats:
 The following QGIS vendor options are supported on line symbolizers with a graphic stroke:
 
 - `<VendorOption name="placement">firstPoint</VendorOption>`
-- `<VendorOption name="placement">lastPointPoint</VendorOption>`
+- `<VendorOption name="placement">lastPoint</VendorOption>`
 
 See the demo page for an example.
 
@@ -85,13 +86,14 @@ Polygons with static fill and stroke style parameters are supported. See LineSym
 For polygon graphic fills, both ExternalGraphic and Mark graphic fills are supported. The Marks supported here are the same as for a point symbolizer, with the additional restriction that feature-dependent value cannot be used.
 
 The following WellKnownNames used by QGIS simple fills can be used as well:
-* x
-* cross
-* line
-* horline
-* slash
-* backslash
-* brush://dense1 (till dense7)
+
+- x
+- cross
+- line
+- horline
+- slash
+- backslash
+- brush://dense1 (till dense7)
 
 #### TextSymbolizer
 
@@ -106,13 +108,29 @@ Dynamic Labels (with PropertyName elements), Font and Halo are supported. No ven
 
 ### Dynamic parameter values
 
-According to the SLD spec, most values can be mixed type (a combination ofplain text and [Filter expressions](https://docs.geoserver.org/stable/en/user/styling/sld/reference/filters.html#sld-filter-expression)). This means that most values can depend on a feature's properties. The SLDReader only supports dynamic values with PropertyName elements in these cases:
+According to the SLD spec, most values can be mixed type (a combination of plain text and [Filter expressions](https://docs.geoserver.org/stable/en/user/styling/sld/reference/filters.html#sld-filter-expression)). This means that most values can depend on feature properties.
+
+SLDReader supports dynamic values in these cases:
 
 - PointSymbolizer Size
 - PointSymbolizer Rotation
 - TextSymbolizer Label
+- SvgParameters used for styling:
+  - `stroke`
+  - `stroke-opacity`
+  - `stroke-width`
+  - `fill`
+  - `fill-opacity`
+  - `font-family`
+  - `font-style`
+  - `font-weight`
+  - `font-size`
 
-Also there is currently no support for arithmetic operators (Add,Sub,Mul,Div).
+**Note:** dynamic parameter values currently have no effect on Marks used inside GraphicStroke or GraphicFill and will use SLD defaults instead.
+
+### Arithmetic operators
+
+There is currently no support for arithmetic operators (Add,Sub,Mul,Div).
 
 ### Units of measure
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: API
-nav_order: 4
+nav_order: 5
 ---
 
 # Basic usage

--- a/docs/assets/benelux.js
+++ b/docs/assets/benelux.js
@@ -18,7 +18,7 @@ const vector = new ol.layer.Vector({
     image: new ol.style.Circle({
       radius: 8,
       fill: new ol.style.Fill({
-        color: 'gray',
+        color: '#808080',
         fillOpacity: 0.7,
       }),
     }),

--- a/docs/assets/dynamic-styling.js
+++ b/docs/assets/dynamic-styling.js
@@ -1,0 +1,99 @@
+/* global ol SLDReader CodeMirror */
+// the xml editor
+const editor = CodeMirror.fromTextArea(document.getElementById('sld'), {
+  lineNumbers: true,
+  lineWrapping: true,
+  mode: 'xml',
+});
+
+const fmtGeoJSON = new ol.format.GeoJSON();
+
+const randomGeoJSON = {
+  type: 'FeatureCollection',
+  features: [],
+};
+
+const weightedRandomColor = (r, g, b) => {
+  const rr = Math.floor((256 * Math.random() + r) / 2);
+  const rg = Math.floor((256 * Math.random() + g) / 2);
+  const rb = Math.floor((256 * Math.random() + b) / 2);
+  // eslint-disable-next-line no-bitwise
+  const colorInt = rb + (rg << 8) + (rr << 16);
+  return `#${colorInt.toString(16)}`;
+};
+
+const numFeatures = 10;
+for (let k = 0; k < numFeatures; k += 1) {
+  const randomPointFeature = {
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [1.4e6 * (Math.random() - 0.5), 7e5 * (Math.random() - 0.5)],
+    },
+    properties: {
+      geometryType: 'Point',
+      myFillColor: weightedRandomColor(255, 0, 0),
+      myFillOpacity: 0.5 + 0.5 * Math.random(),
+      myStrokeColor: weightedRandomColor(128, 0, 0),
+      myStrokeWidth: 2 + 2 * Math.random(),
+      myStrokeOpacity: 0.8 + 0.2 * Math.random(),
+    },
+  };
+  randomGeoJSON.features.push(randomPointFeature);
+}
+
+const randomFeatures = fmtGeoJSON.readFeatures(randomGeoJSON);
+
+const vectorSource = new ol.source.Vector({
+  features: randomFeatures,
+});
+
+window._feat = randomFeatures[0];
+
+const vector = new ol.layer.Vector({
+  source: vectorSource,
+});
+
+const map = new ol.Map({
+  layers: [vector],
+  target: document.getElementById('olmap'),
+  view: new ol.View({
+    center: [0, 0],
+    maxZoom: 19,
+    zoom: 6,
+  }),
+});
+map.addControl(new ol.control.MousePosition());
+
+/**
+ * @param {object} vector layer
+ * @param {string} text the xml text
+ * apply sld
+ */
+function applySLD(vectorLayer, text) {
+  const sldObject = SLDReader.Reader(text);
+  // for debugging
+  window.sldObject = sldObject;
+  const sldLayer = SLDReader.getLayer(sldObject);
+  const style = SLDReader.getStyle(sldLayer);
+  const featureTypeStyle = style.featuretypestyles[0];
+
+  vectorLayer.setStyle(SLDReader.createOlStyleFunction(featureTypeStyle, {
+    imageLoadedCallback: () => {
+      // Signal OpenLayers to redraw the layer when an image icon has loaded.
+      // On redraw, the updated symbolizer with the correct image scale will be used to draw the icon.
+      vectorLayer.changed();
+    },
+  }));
+}
+
+fetch('assets/sld-dynamic-styling.xml')
+  .then(response => response.text())
+  .then(text => editor.setValue(text));
+
+/**
+ * update map if sld is edited
+ */
+editor.on('change', cm => {
+  applySLD(vector, cm.getValue());
+});

--- a/docs/assets/dynamic-styling.js
+++ b/docs/assets/dynamic-styling.js
@@ -22,24 +22,88 @@ const weightedRandomColor = (r, g, b) => {
   return `#${colorInt.toString(16)}`;
 };
 
-const numFeatures = 10;
+const numFeatures = 15;
 for (let k = 0; k < numFeatures; k += 1) {
-  const randomPointFeature = {
-    type: 'Feature',
-    geometry: {
-      type: 'Point',
-      coordinates: [1.4e6 * (Math.random() - 0.5), 7e5 * (Math.random() - 0.5)],
-    },
-    properties: {
-      geometryType: 'Point',
-      myFillColor: weightedRandomColor(255, 0, 0),
-      myFillOpacity: 0.5 + 0.5 * Math.random(),
-      myStrokeColor: weightedRandomColor(128, 0, 0),
-      myStrokeWidth: 2 + 2 * Math.random(),
-      myStrokeOpacity: 0.8 + 0.2 * Math.random(),
-    },
-  };
-  randomGeoJSON.features.push(randomPointFeature);
+  const centerX = 1.4e6 * (Math.random() - 0.5);
+  const centerY = 7e5 * (Math.random() - 0.5);
+
+  const rx = Math.random();
+
+  if (rx < 0.333333) {
+    // Create random point feature.
+    const randomPointFeature = {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [centerX, centerY],
+      },
+      properties: {
+        geometryType: 'Point',
+        mySize: 10 * (1 + Math.random()),
+        myFillColor: weightedRandomColor(255, 0, 0),
+        myFillOpacity: 0.5 + 0.5 * Math.random(),
+        myStrokeColor: weightedRandomColor(128, 0, 0),
+        myStrokeWidth: 1 + 3 * Math.random(),
+        myStrokeOpacity: 0.8 + 0.2 * Math.random(),
+      },
+    };
+    randomGeoJSON.features.push(randomPointFeature);
+  } else if (rx < 0.666667) {
+    // Create random line string
+    let [px, py] = [centerX, centerY];
+    const linePoints = [[px, py]];
+    const numSegments = 15 + Math.floor(Math.random() * 5);
+    let alpha = 2 * Math.PI * Math.random();
+    for (let i = 0; i < numSegments; i += 1) {
+      const segLen = 2e4 * (1.0 + Math.random());
+      px += segLen * Math.cos(alpha);
+      py += segLen * Math.sin(alpha);
+      alpha += 2 * (Math.random() - 0.5);
+      linePoints.push([px, py]);
+    }
+    const randomLineStringFeature = {
+      type: 'Feature',
+      geometry: {
+        type: 'LineString',
+        coordinates: linePoints,
+      },
+      properties: {
+        geometryType: 'LineString',
+        myStrokeColor: weightedRandomColor(0, 255, 0),
+        myStrokeWidth: 1 + 3 * Math.random(),
+        myStrokeOpacity: 0.8 + 0.2 * Math.random(),
+      },
+    };
+    randomGeoJSON.features.push(randomLineStringFeature);
+  } else {
+    // Create random rectangle
+    const halfWidth = 5e4 * (1 + Math.random());
+    const halfHeight = 5e4 * (1 + Math.random());
+    const randomPolygonFeature = {
+      type: 'Feature',
+      geometry: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [centerX - halfWidth, centerY - halfHeight],
+            [centerX - halfWidth, centerY + halfHeight],
+            [centerX + halfWidth, centerY + halfHeight],
+            [centerX + halfWidth, centerY - halfHeight],
+            [centerX - halfWidth, centerY - halfHeight],
+          ],
+        ],
+      },
+      properties: {
+        geometryType: 'Polygon',
+        myFillColor: weightedRandomColor(0, 0, 255),
+        myFillOpacity: 0.5 + 0.5 * Math.random(),
+        myStrokeColor: weightedRandomColor(0, 0, 128),
+        myStrokeWidth: 1 + 3 * Math.random(),
+        myStrokeOpacity: 0.8 + 0.2 * Math.random(),
+      },
+    };
+    randomGeoJSON.features.push(randomPolygonFeature);
+  }
 }
 
 const randomFeatures = fmtGeoJSON.readFeatures(randomGeoJSON);
@@ -60,7 +124,7 @@ const map = new ol.Map({
   view: new ol.View({
     center: [0, 0],
     maxZoom: 19,
-    zoom: 6,
+    zoom: 5,
   }),
 });
 map.addControl(new ol.control.MousePosition());

--- a/docs/assets/sld-dynamic-styling.xml
+++ b/docs/assets/sld-dynamic-styling.xml
@@ -17,7 +17,7 @@
           <se:PointSymbolizer>
             <se:Graphic>
               <se:Mark>
-                <se:WellKnownName>circle</se:WellKnownName>
+                <se:WellKnownName>triangle</se:WellKnownName>
                 <se:Fill>
                   <se:SvgParameter name="fill">
                     <ogc:PropertyName>myFillColor</ogc:PropertyName>
@@ -38,9 +38,61 @@
                   </se:SvgParameter>
                 </se:Stroke>
               </se:Mark>
-              <se:Size>10</se:Size>
+              <se:Size>
+                <ogc:PropertyName>mySize</ogc:PropertyName>
+              </se:Size>
             </se:Graphic>
           </se:PointSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:PropertyIsEqualTo>
+              <ogc:PropertyName>geometryType</ogc:PropertyName>
+              <ogc:Literal>LineString</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <se:LineSymbolizer>
+            <se:Stroke>
+              <se:SvgParameter name="stroke">
+                <ogc:PropertyName>myStrokeColor</ogc:PropertyName>
+              </se:SvgParameter>
+              <se:SvgParameter name="stroke-opacity">
+                <ogc:PropertyName>myStrokeOpacity</ogc:PropertyName>
+              </se:SvgParameter>
+              <se:SvgParameter name="stroke-width">
+                <ogc:PropertyName>myStrokeWidth</ogc:PropertyName>
+              </se:SvgParameter>
+            </se:Stroke>
+          </se:LineSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:PropertyIsEqualTo>
+              <ogc:PropertyName>geometryType</ogc:PropertyName>
+              <ogc:Literal>Polygon</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <se:PolygonSymbolizer>
+            <se:Fill>
+              <se:SvgParameter name="fill">
+                <ogc:PropertyName>myFillColor</ogc:PropertyName>
+              </se:SvgParameter>
+              <se:SvgParameter name="fill-opacity">
+                <ogc:PropertyName>myFillOpacity</ogc:PropertyName>
+              </se:SvgParameter>
+            </se:Fill>
+            <se:Stroke>
+              <se:SvgParameter name="stroke">
+                <ogc:PropertyName>myStrokeColor</ogc:PropertyName>
+              </se:SvgParameter>
+              <se:SvgParameter name="stroke-opacity">
+                <ogc:PropertyName>myStrokeOpacity</ogc:PropertyName>
+              </se:SvgParameter>
+              <se:SvgParameter name="stroke-width">
+                <ogc:PropertyName>myStrokeWidth</ogc:PropertyName>
+              </se:SvgParameter>
+            </se:Stroke>
+          </se:PolygonSymbolizer>
         </se:Rule>
       </se:FeatureTypeStyle>
     </UserStyle>

--- a/docs/assets/sld-dynamic-styling.xml
+++ b/docs/assets/sld-dynamic-styling.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd"
+  xmlns:se="http://www.opengis.net/se">
+  <NamedLayer>
+    <UserStyle>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:PropertyIsEqualTo>
+              <ogc:PropertyName>geometryType</ogc:PropertyName>
+              <ogc:Literal>Point</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">
+                    <ogc:PropertyName>myFillColor</ogc:PropertyName>
+                  </se:SvgParameter>
+                  <se:SvgParameter name="fill-opacity">
+                    <ogc:PropertyName>myFillOpacity</ogc:PropertyName>
+                  </se:SvgParameter>
+                </se:Fill>
+                <se:Stroke>
+                  <se:SvgParameter name="stroke">
+                    <ogc:PropertyName>myStrokeColor</ogc:PropertyName>
+                  </se:SvgParameter>
+                  <se:SvgParameter name="stroke-opacity">
+                    <ogc:PropertyName>myStrokeOpacity</ogc:PropertyName>
+                  </se:SvgParameter>
+                  <se:SvgParameter name="stroke-width">
+                    <ogc:PropertyName>myStrokeWidth</ogc:PropertyName>
+                  </se:SvgParameter>
+                </se:Stroke>
+              </se:Mark>
+              <se:Size>10</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -3008,7 +3008,7 @@
       // Todo: do this at the SLDReader parsing stage already.
       if (!mark.stroke.styling) {
         mark.stroke.styling = {
-          stroke: 'black',
+          stroke: '#000000',
           strokeWidth: 1.0,
         };
       }
@@ -3039,7 +3039,7 @@
 
     // If it's a QGIS brush fill, use direct pixel manipulation to create the fill.
     if (wellknownname && wellknownname.indexOf('brush://') === 0) {
-      var brushFillColor = 'black';
+      var brushFillColor = '#000000';
       if (mark.fill && mark.fill.styling && mark.fill.styling.fill) {
         brushFillColor = mark.fill.styling.fill;
       }
@@ -3132,7 +3132,7 @@
     } catch (e) {
       // Default black fill as backup plan.
       fill = new style.Fill({
-        color: 'black',
+        color: '#000000',
       });
     }
 

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -2091,6 +2091,10 @@
       return false;
     }
 
+    if (typeof getProperty !== 'function') {
+      return false;
+    }
+
     var somethingChanged = false;
 
     var fill = symbolizer.fill || {};
@@ -2132,6 +2136,10 @@
   ) {
     var olStroke = olStyle.getStroke();
     if (!olStroke) {
+      return false;
+    }
+
+    if (typeof getProperty !== 'function') {
       return false;
     }
 

--- a/docs/benelux.html
+++ b/docs/benelux.html
@@ -6,7 +6,6 @@ nav_order: 2
 <div class="row">
   <div class="col-md-12">
     <h1>Point symbolizers with ExternalGraphic</h1>
-    <p>This example requires an up to date browser!</p>
     <p><a href="assets/benelux.js">View code</a></p>
   </div>
 </div>

--- a/docs/dynamic-styling.html
+++ b/docs/dynamic-styling.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Dynamic svg style properties
+title: Dynamic style properties
 nav_order: 4
 ---
 <div class="row">

--- a/docs/dynamic-styling.html
+++ b/docs/dynamic-styling.html
@@ -1,0 +1,23 @@
+---
+layout: default
+title: Dynamic svg style properties
+nav_order: 4
+---
+<div class="row">
+  <div class="col-md-12">
+    <h1>Dynamic style properties</h1>
+    <p><a href="assets/dynamic-styling.js">View code</a></p>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-6">
+    <div id="olmap"></div>
+  </div>
+  <div class="col-md-6">
+    <textarea id="sld"></textarea>
+  </div>
+</div>
+</div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.41.0/codemirror.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.41.0/mode/xml/xml.min.js"></script>
+<script src="assets/dynamic-styling.js"></script>

--- a/docs/grenzen.html
+++ b/docs/grenzen.html
@@ -7,7 +7,6 @@ nav_order: 3
 <div class="row">
   <div class="col-md-12">
     <h1>Provinces of the netherlands</h1>
-    <p>This example requires an up to date browser!</p>
     <p><a href="assets/grenzen.js">View code</a></p>
   </div>
 </div>

--- a/docs/hoogspanning.html
+++ b/docs/hoogspanning.html
@@ -30,7 +30,6 @@ nav_order: 3
 
 <div>
   <h1>GraphicStroke</h1>
-  <p>This example requires an up to date browser!</p>
   <p><a href="assets/hoogspanning.js">View code</a></p>
 </div>
 <div class="button-box">

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -9,6 +9,7 @@ const numericSvgProps = new Set([
   'strokeOpacity',
   'strokeDashoffset',
   'fillOpacity',
+  'fontSize',
 ]);
 
 /**

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -7,7 +7,7 @@ import createFilter from './filter';
 const numericSvgProps = new Set([
   'strokeWidth',
   'strokeOpacity',
-  'strokeDashOffset',
+  'strokeDashoffset',
   'fillOpacity',
 ]);
 

--- a/src/styles/dynamicStyles.js
+++ b/src/styles/dynamicStyles.js
@@ -1,5 +1,5 @@
 import evaluate, { isDynamicExpression } from '../olEvaluator';
-import { hexToRGB } from './styleUtils';
+import { getOLColorString } from './styleUtils';
 
 /**
  * Change OL Style fill properties for dynamic symbolizer style parameters.
@@ -29,21 +29,14 @@ export function applyDynamicFillStyling(
     isDynamicExpression(styling.fill) ||
     isDynamicExpression(styling.fillOpacity)
   ) {
-    let fillColor = evaluate(styling.fill, feature, getProperty, '#808080');
+    const fillColor = evaluate(styling.fill, feature, getProperty, '#808080');
     const fillOpacity = evaluate(
       styling.fillOpacity,
       feature,
       getProperty,
       1.0
     );
-    if (
-      fillOpacity !== null &&
-      fillOpacity < 1.0 &&
-      fillColor.startsWith('#')
-    ) {
-      fillColor = hexToRGB(fillColor, fillOpacity);
-    }
-    olFill.setColor(fillColor);
+    olFill.setColor(getOLColorString(fillColor, fillOpacity));
   }
 }
 
@@ -86,20 +79,18 @@ export function applyDynamicStrokeStyling(
     isDynamicExpression(styling.stroke) ||
     isDynamicExpression(styling.strokeOpacity)
   ) {
-    let strokeColor = evaluate(styling.stroke, feature, getProperty, '#000000');
+    const strokeColor = evaluate(
+      styling.stroke,
+      feature,
+      getProperty,
+      '#000000'
+    );
     const strokeOpacity = evaluate(
       styling.strokeOpacity,
       feature,
       getProperty,
       1.0
     );
-    if (
-      strokeOpacity !== null &&
-      strokeOpacity < 1.0 &&
-      strokeColor.startsWith('#')
-    ) {
-      strokeColor = hexToRGB(strokeColor, strokeOpacity);
-    }
-    olStroke.setColor(strokeColor);
+    olStroke.setColor(getOLColorString(strokeColor, strokeOpacity));
   }
 }

--- a/src/styles/dynamicStyles.js
+++ b/src/styles/dynamicStyles.js
@@ -21,6 +21,10 @@ export function applyDynamicFillStyling(
     return false;
   }
 
+  if (typeof getProperty !== 'function') {
+    return false;
+  }
+
   let somethingChanged = false;
 
   const fill = symbolizer.fill || {};
@@ -62,6 +66,10 @@ export function applyDynamicStrokeStyling(
 ) {
   const olStroke = olStyle.getStroke();
   if (!olStroke) {
+    return false;
+  }
+
+  if (typeof getProperty !== 'function') {
     return false;
   }
 

--- a/src/styles/dynamicStyles.js
+++ b/src/styles/dynamicStyles.js
@@ -1,0 +1,105 @@
+import evaluate, { isDynamicExpression } from '../olEvaluator';
+import { hexToRGB } from './styleUtils';
+
+/**
+ * Change OL Style fill properties for dynamic symbolizer style parameters.
+ * Modification happens in-place on the given style instance.
+ * @param {ol/style/Style} olStyle OL Style instance.
+ * @param {object} symbolizer SLD symbolizer object.
+ * @param {ol/Feature|GeoJSON} feature OL Feature instance or GeoJSON feature object.
+ * @param {Function} getProperty Property getter (feature, propertyName) => propertyValue.
+ * @returns {void} The input style instance (adjustments are made in-place).
+ */
+export function applyDynamicFillStyling(
+  olStyle,
+  symbolizer,
+  feature,
+  getProperty
+) {
+  const olFill = olStyle.getFill();
+  if (!olFill) {
+    return;
+  }
+
+  const stroke = symbolizer.fill || {};
+  const styling = stroke.styling || {};
+
+  // Change fill color if either color or opacity is property based.
+  if (
+    isDynamicExpression(styling.fill) ||
+    isDynamicExpression(styling.fillOpacity)
+  ) {
+    let fillColor = evaluate(styling.fill, feature, getProperty, '#808080');
+    const fillOpacity = evaluate(
+      styling.fillOpacity,
+      feature,
+      getProperty,
+      1.0
+    );
+    if (
+      fillOpacity !== null &&
+      fillOpacity < 1.0 &&
+      fillColor.startsWith('#')
+    ) {
+      fillColor = hexToRGB(fillColor, fillOpacity);
+    }
+    olFill.setColor(fillColor);
+  }
+}
+
+/**
+ * Change OL Style stroke properties for dynamic symbolizer style parameters.
+ * Modification happens in-place on the given style instance.
+ * @param {ol/style/Style} olStyle OL Style instance.
+ * @param {object} symbolizer SLD symbolizer object.
+ * @param {ol/Feature|GeoJSON} feature OL Feature instance or GeoJSON feature object.
+ * @param {Function} getProperty Property getter (feature, propertyName) => propertyValue.
+ * @returns {void}
+ */
+export function applyDynamicStrokeStyling(
+  olStyle,
+  symbolizer,
+  feature,
+  getProperty
+) {
+  const olStroke = olStyle.getStroke();
+  if (!olStroke) {
+    return;
+  }
+
+  const stroke = symbolizer.stroke || {};
+  const styling = stroke.styling || {};
+
+  // Change stroke width if it's property based.
+  if (isDynamicExpression(styling.strokeWidth)) {
+    const strokeWidth = evaluate(
+      styling.strokeWidth,
+      feature,
+      getProperty,
+      1.0
+    );
+    olStroke.setWidth(strokeWidth);
+  }
+
+  // Change stroke color if either color or opacity is property based.
+  if (
+    isDynamicExpression(styling.stroke) ||
+    isDynamicExpression(styling.strokeOpacity)
+  ) {
+    let strokeColor = evaluate(styling.stroke, feature, getProperty, '#000000');
+    const strokeOpacity = evaluate(
+      styling.strokeOpacity,
+      feature,
+      getProperty,
+      1.0
+    );
+    if (
+      strokeOpacity !== null &&
+      strokeOpacity < 1.0 &&
+      strokeColor.startsWith('#')
+    ) {
+      strokeColor = hexToRGB(strokeColor, strokeOpacity);
+    }
+    olStroke.setColor(strokeColor);
+  }
+}

--- a/src/styles/dynamicStyles.js
+++ b/src/styles/dynamicStyles.js
@@ -8,7 +8,7 @@ import { getOLColorString } from './styleUtils';
  * @param {object} symbolizer SLD symbolizer object.
  * @param {ol/Feature|GeoJSON} feature OL Feature instance or GeoJSON feature object.
  * @param {Function} getProperty Property getter (feature, propertyName) => propertyValue.
- * @returns {void} The input style instance (adjustments are made in-place).
+ * @returns {bool} Returns true if any property-dependent fill style changes have been made.
  */
 export function applyDynamicFillStyling(
   olStyle,
@@ -18,11 +18,13 @@ export function applyDynamicFillStyling(
 ) {
   const olFill = olStyle.getFill();
   if (!olFill) {
-    return;
+    return false;
   }
 
-  const stroke = symbolizer.fill || {};
-  const styling = stroke.styling || {};
+  let somethingChanged = false;
+
+  const fill = symbolizer.fill || {};
+  const styling = fill.styling || {};
 
   // Change fill color if either color or opacity is property based.
   if (
@@ -37,7 +39,10 @@ export function applyDynamicFillStyling(
       1.0
     );
     olFill.setColor(getOLColorString(fillColor, fillOpacity));
+    somethingChanged = true;
   }
+
+  return somethingChanged;
 }
 
 /**
@@ -47,7 +52,7 @@ export function applyDynamicFillStyling(
  * @param {object} symbolizer SLD symbolizer object.
  * @param {ol/Feature|GeoJSON} feature OL Feature instance or GeoJSON feature object.
  * @param {Function} getProperty Property getter (feature, propertyName) => propertyValue.
- * @returns {void}
+ * @returns {bool} Returns true if any property-dependent stroke style changes have been made.
  */
 export function applyDynamicStrokeStyling(
   olStyle,
@@ -57,8 +62,10 @@ export function applyDynamicStrokeStyling(
 ) {
   const olStroke = olStyle.getStroke();
   if (!olStroke) {
-    return;
+    return false;
   }
+
+  let somethingChanged = false;
 
   const stroke = symbolizer.stroke || {};
   const styling = stroke.styling || {};
@@ -72,6 +79,7 @@ export function applyDynamicStrokeStyling(
       1.0
     );
     olStroke.setWidth(strokeWidth);
+    somethingChanged = true;
   }
 
   // Change stroke color if either color or opacity is property based.
@@ -92,5 +100,8 @@ export function applyDynamicStrokeStyling(
       1.0
     );
     olStroke.setColor(getOLColorString(strokeColor, strokeOpacity));
+    somethingChanged = true;
   }
+
+  return somethingChanged;
 }

--- a/src/styles/graphicStrokeStyle.js
+++ b/src/styles/graphicStrokeStyle.js
@@ -171,7 +171,12 @@ export function getGraphicStrokeRenderer(linesymbolizer, getProperty) {
       (graphicstroke.graphic && graphicstroke.graphic.size) ||
       defaultGraphicSize;
     const graphicSize = Number(
-      evaluate(graphicSizeExpression, renderState.feature, getProperty)
+      evaluate(
+        graphicSizeExpression,
+        renderState.feature,
+        getProperty,
+        defaultGraphicSize
+      )
     );
 
     const graphicSpacing = calculateGraphicSpacing(linesymbolizer, graphicSize);

--- a/src/styles/lineStyle.js
+++ b/src/styles/lineStyle.js
@@ -3,6 +3,7 @@ import { Style } from 'ol/style';
 import { memoizeStyleFunction } from './styleUtils';
 import { getSimpleStroke } from './simpleStyles';
 import getGraphicStrokeStyle from './graphicStrokeStyle';
+import { applyDynamicStrokeStyling } from './dynamicStyles';
 
 /**
  * @private
@@ -27,8 +28,13 @@ const cachedLineStyle = memoizeStyleFunction(lineStyle);
  * @param {object} symbolizer SLD symbolizer object.
  * @returns {ol/Style} OpenLayers style instance.
  */
-function getLineStyle(symbolizer) {
-  return cachedLineStyle(symbolizer);
+function getLineStyle(symbolizer, feature, getProperty) {
+  const olStyle = cachedLineStyle(symbolizer);
+
+  // Apply dynamic properties.
+  applyDynamicStrokeStyling(olStyle, symbolizer, feature, getProperty);
+
+  return olStyle;
 }
 
 export default getLineStyle;

--- a/src/styles/pointStyle.js
+++ b/src/styles/pointStyle.js
@@ -16,6 +16,10 @@ import { createCachedImageStyle, getImageLoadingState } from '../imageCache';
 import getWellKnownSymbol from './wellknown';
 import evaluate, { isDynamicExpression } from '../olEvaluator';
 import { getSimpleFill, getSimpleStroke } from './simpleStyles';
+import {
+  applyDynamicFillStyling,
+  applyDynamicStrokeStyling,
+} from './dynamicStyles';
 
 const defaultMarkFill = getSimpleFill({ styling: { fill: '#888888' } });
 const defaultMarkStroke = getSimpleStroke({ styling: { stroke: {} } });
@@ -151,6 +155,12 @@ function getPointStyle(symbolizer, feature, getProperty) {
     // Note: OL angles are in radians.
     const rotationRadians = (Math.PI * rotationDegrees) / 180.0;
     olImage.setRotation(rotationRadians);
+  }
+
+  // --- Update stroke and fill ---
+  if (graphic.mark) {
+    applyDynamicStrokeStyling(olImage, graphic.mark, feature, getProperty);
+    applyDynamicFillStyling(olImage, graphic.mark, feature, getProperty);
   }
 
   return olStyle;

--- a/src/styles/pointStyle.js
+++ b/src/styles/pointStyle.js
@@ -159,8 +159,32 @@ function getPointStyle(symbolizer, feature, getProperty) {
 
   // --- Update stroke and fill ---
   if (graphic.mark) {
-    applyDynamicStrokeStyling(olImage, graphic.mark, feature, getProperty);
-    applyDynamicFillStyling(olImage, graphic.mark, feature, getProperty);
+    const strokeChanged = applyDynamicStrokeStyling(
+      olImage,
+      graphic.mark,
+      feature,
+      getProperty
+    );
+
+    const fillChanged = applyDynamicFillStyling(
+      olImage,
+      graphic.mark,
+      feature,
+      getProperty
+    );
+
+    if (strokeChanged || fillChanged) {
+      // Create a new olImage in order to force a re-render to see the style changes.
+      const sizeValue =
+        Number(evaluate(size, feature, getProperty)) || DEFAULT_MARK_SIZE;
+      olImage = getWellKnownSymbol(
+        (graphic.mark && graphic.mark.wellknownname) || 'square',
+        sizeValue,
+        olImage.getStroke(),
+        olImage.getFill()
+      );
+      olStyle.setImage(olImage);
+    }
   }
 
   return olStyle;

--- a/src/styles/polygonStyle.js
+++ b/src/styles/polygonStyle.js
@@ -95,7 +95,7 @@ function scaleMarkGraphicFill(graphicfill, scaleFactor) {
     // Todo: do this at the SLDReader parsing stage already.
     if (!mark.stroke.styling) {
       mark.stroke.styling = {
-        stroke: 'black',
+        stroke: '#000000',
         strokeWidth: 1.0,
       };
     }
@@ -124,7 +124,7 @@ function getMarkGraphicFill(symbolizer) {
 
   // If it's a QGIS brush fill, use direct pixel manipulation to create the fill.
   if (wellknownname && wellknownname.indexOf('brush://') === 0) {
-    let brushFillColor = 'black';
+    let brushFillColor = '#000000';
     if (mark.fill && mark.fill.styling && mark.fill.styling.fill) {
       brushFillColor = mark.fill.styling.fill;
     }
@@ -217,7 +217,7 @@ function getMarkGraphicFill(symbolizer) {
   } catch (e) {
     // Default black fill as backup plan.
     fill = new Fill({
-      color: 'black',
+      color: '#000000',
     });
   }
 

--- a/src/styles/polygonStyle.js
+++ b/src/styles/polygonStyle.js
@@ -14,6 +14,7 @@ import { memoizeStyleFunction } from './styleUtils';
 import { getCachedImage, getImageLoadingState } from '../imageCache';
 import { imageLoadingPolygonStyle, imageErrorPolygonStyle } from './static';
 import { getSimpleStroke, getSimpleFill } from './simpleStyles';
+import { applyDynamicFillStyling, applyDynamicStrokeStyling } from './dynamicStyles';
 import { getGraphicStrokeRenderer } from './graphicStrokeStyle';
 import getPointStyle from './pointStyle';
 import getQGISBrushFill from './qgisBrushFill';
@@ -288,8 +289,14 @@ const cachedPolygonStyle = memoizeStyleFunction(polygonStyle);
  * @param {object} symbolizer SLD symbolizer object.
  * @returns {ol/Style} OpenLayers style instance.
  */
-function getPolygonStyle(symbolizer) {
-  return cachedPolygonStyle(symbolizer);
+function getPolygonStyle(symbolizer, feature, getProperty) {
+  const olStyle = cachedPolygonStyle(symbolizer);
+
+  // Apply dynamic properties.
+  applyDynamicFillStyling(olStyle, symbolizer, feature, getProperty);
+  applyDynamicStrokeStyling(olStyle, symbolizer, feature, getProperty);
+
+  return olStyle;
 }
 
 export default getPolygonStyle;

--- a/src/styles/simpleStyles.js
+++ b/src/styles/simpleStyles.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 import { Stroke, Fill } from 'ol/style';
 
-import { hexToRGB } from './styleUtils';
+import { getOLColorString } from './styleUtils';
 import evaluate from '../olEvaluator';
 
 /**
@@ -21,11 +21,9 @@ export function getSimpleStroke(stroke) {
   const styleParams = stroke.styling || {};
 
   // Options that have a default value.
-  let strokeColor = evaluate(styleParams.stroke, null, null, '#000000');
+  const strokeColor = evaluate(styleParams.stroke, null, null, '#000000');
+
   const strokeOpacity = evaluate(styleParams.strokeOpacity, null, null);
-  if (strokeOpacity !== null && strokeColor.startsWith('#')) {
-    strokeColor = hexToRGB(strokeColor, strokeOpacity);
-  }
 
   const strokeWidth = evaluate(styleParams.strokeWidth, null, null, 1.0);
 
@@ -37,7 +35,7 @@ export function getSimpleStroke(stroke) {
   );
 
   const strokeOptions = {
-    color: strokeColor,
+    color: getOLColorString(strokeColor, strokeOpacity),
     width: strokeWidth,
     lineDashOffset: strokeLineDashOffset,
   };
@@ -77,11 +75,9 @@ export function getSimpleFill(fill) {
 
   const styleParams = fill.styling || {};
 
-  let fillColor = evaluate(styleParams.fill, null, null, '#808080');
-  const fillOpacity = evaluate(styleParams.fillOpacity, null, null);
-  if (fillOpacity !== null && fillColor.startsWith('#')) {
-    fillColor = hexToRGB(fillColor, fillOpacity);
-  }
+  const fillColor = evaluate(styleParams.fill, null, null, '#808080');
 
-  return new Fill({ color: fillColor });
+  const fillOpacity = evaluate(styleParams.fillOpacity, null, null);
+
+  return new Fill({ color: getOLColorString(fillColor, fillOpacity) });
 }

--- a/src/styles/simpleStyles.js
+++ b/src/styles/simpleStyles.js
@@ -23,7 +23,7 @@ export function getSimpleStroke(stroke) {
   // Options that have a default value.
   const strokeColor = evaluate(styleParams.stroke, null, null, '#000000');
 
-  const strokeOpacity = evaluate(styleParams.strokeOpacity, null, null);
+  const strokeOpacity = evaluate(styleParams.strokeOpacity, null, null, 1.0);
 
   const strokeWidth = evaluate(styleParams.strokeWidth, null, null, 1.0);
 
@@ -77,7 +77,7 @@ export function getSimpleFill(fill) {
 
   const fillColor = evaluate(styleParams.fill, null, null, '#808080');
 
-  const fillOpacity = evaluate(styleParams.fillOpacity, null, null);
+  const fillOpacity = evaluate(styleParams.fillOpacity, null, null, 1.0);
 
   return new Fill({ color: getOLColorString(fillColor, fillOpacity) });
 }

--- a/src/styles/styleUtils.js
+++ b/src/styles/styleUtils.js
@@ -32,7 +32,7 @@ export function memoizeStyleFunction(styleFunction) {
  * @param  {Number} alpha eg 0.5
  * @return {string}       rgba(0,0,0,0)
  */
-export function hexToRGB(hex, alpha) {
+function hexToRGB(hex, alpha) {
   const r = parseInt(hex.slice(1, 3), 16);
   const g = parseInt(hex.slice(3, 5), 16);
   const b = parseInt(hex.slice(5, 7), 16);
@@ -40,6 +40,19 @@ export function hexToRGB(hex, alpha) {
     return `rgba(${r}, ${g}, ${b}, ${alpha})`;
   }
   return `rgb(${r}, ${g}, ${b})`;
+}
+
+/**
+ * Get color string for OpenLayers. Encodes opacity into color string if it's a number less than 1.
+ * @param {string} color Color string, encoded as #AABBCC.
+ * @param {number} opacity Opacity. Non-numeric values will be treated as 1.
+ * @returns {string} OpenLayers color string.
+ */
+export function getOLColorString(color, opacity) {
+  if (opacity !== null && opacity < 1.0 && color.startsWith('#')) {
+    return hexToRGB(color, opacity);
+  }
+  return color;
 }
 
 /**

--- a/src/styles/textStyle.js
+++ b/src/styles/textStyle.js
@@ -20,14 +20,6 @@ function textStyle(textsymbolizer) {
   const labelText = evaluate(textsymbolizer.label, null, null, '');
 
   const fill = textsymbolizer.fill ? textsymbolizer.fill.styling : {};
-  const halo =
-    textsymbolizer.halo && textsymbolizer.halo.fill
-      ? textsymbolizer.halo.fill.styling
-      : {};
-  const haloRadius =
-    textsymbolizer.halo && textsymbolizer.halo.radius
-      ? parseFloat(textsymbolizer.halo.radius)
-      : 1;
   const {
     fontFamily = 'sans-serif',
     fontSize = 10,
@@ -99,11 +91,15 @@ function textStyle(textsymbolizer) {
     }),
   };
 
-  const haloFillColor = evaluate(halo.fill, null, null, '#FFFFFF');
-  const haloFillOpacity = evaluate(halo.fillOpacity, null, null, 1.0);
-
   // Convert SLD halo to text symbol stroke.
   if (textsymbolizer.halo) {
+    const haloStyling =
+      textsymbolizer.halo && textsymbolizer.halo.fill
+        ? textsymbolizer.halo.fill.styling
+        : {};
+    const haloFillColor = evaluate(haloStyling.fill, null, null, '#FFFFFF');
+    const haloFillOpacity = evaluate(haloStyling.fillOpacity, null, null, 1.0);
+    const haloRadius = evaluate(textsymbolizer.halo.radius, null, null, 1.0);
     textStyleOptions.stroke = new Stroke({
       color: getOLColorString(haloFillColor, haloFillOpacity),
       // wrong position width radius equal to 2 or 4

--- a/src/styles/textStyle.js
+++ b/src/styles/textStyle.js
@@ -137,7 +137,7 @@ function getTextStyle(symbolizer, feature, getProperty) {
 
   // Set text only if the label expression is dynamic.
   if (isDynamicExpression(label)) {
-    const labelText = evaluate(label, feature, getProperty);
+    const labelText = evaluate(label, feature, getProperty, '');
     // Important! OpenLayers expects the text property to always be a string.
     olText.setText(labelText.toString());
   }
@@ -152,7 +152,8 @@ function getTextStyle(symbolizer, feature, getProperty) {
       const labelRotationDegrees = evaluate(
         pointPlacementRotation,
         feature,
-        getProperty
+        getProperty,
+        0.0
       );
       olText.setRotation((Math.PI * labelRotationDegrees) / 180.0); // OL rotation is in radians.
     }

--- a/src/styles/textStyle.js
+++ b/src/styles/textStyle.js
@@ -2,6 +2,7 @@ import { Style, Fill, Stroke, Text } from 'ol/style';
 import { getOLColorString, memoizeStyleFunction } from './styleUtils';
 import evaluate, { isDynamicExpression } from '../olEvaluator';
 import { emptyStyle } from './static';
+import { applyDynamicTextStyling } from './dynamicStyles';
 
 /**
  * @private
@@ -19,15 +20,14 @@ function textStyle(textsymbolizer) {
   // In that case, text will be set at runtime.
   const labelText = evaluate(textsymbolizer.label, null, null, '');
 
-  const fill = textsymbolizer.fill ? textsymbolizer.fill.styling : {};
-  const {
-    fontFamily = 'sans-serif',
-    fontSize = 10,
-    fontStyle = '',
-    fontWeight = '',
-  } = textsymbolizer.font && textsymbolizer.font.styling
-    ? textsymbolizer.font.styling
+  const fontStyling = textsymbolizer.font
+    ? textsymbolizer.font.styling || {}
     : {};
+  const fontFamily = evaluate(fontStyling.fontFamily, null, null, 'sans-serif');
+  const fontSize = evaluate(fontStyling.fontSize, null, null, 10);
+  const fontStyle = evaluate(fontStyling.fontStyle, null, null, '');
+  const fontWeight = evaluate(fontStyling.fontWeight, null, null, '');
+  const olFontString = `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`;
 
   const pointplacement =
     textsymbolizer &&
@@ -48,41 +48,38 @@ function textStyle(textsymbolizer) {
     pointplacement && pointplacement.displacement
       ? pointplacement.displacement
       : {};
-  const offsetX = displacement.displacementx ? displacement.displacementx : 0;
-  const offsetY = displacement.displacementy ? displacement.displacementy : 0;
+  const offsetX = evaluate(displacement.displacementx, null, null, 0.0);
+  const offsetY = evaluate(displacement.displacementy, null, null, 0.0);
 
   // OpenLayers does not support fractional alignment, so snap the anchor to the most suitable option.
   const anchorpoint = (pointplacement && pointplacement.anchorpoint) || {};
 
   let textAlign = 'center';
-  const anchorpointx = Number(
-    anchorpoint.anchorpointx === '' ? NaN : anchorpoint.anchorpointx
-  );
-  if (anchorpointx < 0.25) {
+  const anchorPointX = evaluate(anchorpoint.anchorpointx, null, null, NaN);
+  if (anchorPointX < 0.25) {
     textAlign = 'left';
-  } else if (anchorpointx > 0.75) {
+  } else if (anchorPointX > 0.75) {
     textAlign = 'right';
   }
 
   let textBaseline = 'middle';
-  const anchorpointy = Number(
-    anchorpoint.anchorpointy === '' ? NaN : anchorpoint.anchorpointy
-  );
-  if (anchorpointy < 0.25) {
+  const anchorPointY = evaluate(anchorpoint.anchorpointy, null, null, NaN);
+  if (anchorPointY < 0.25) {
     textBaseline = 'bottom';
-  } else if (anchorpointy > 0.75) {
+  } else if (anchorPointY > 0.75) {
     textBaseline = 'top';
   }
 
-  const textFillColor = evaluate(fill.fill, null, null, '#000000');
-  const textFillOpacity = evaluate(fill.fillOpacity, null, null, 1.0);
+  const fillStyling = textsymbolizer.fill ? textsymbolizer.fill.styling : {};
+  const textFillColor = evaluate(fillStyling.fill, null, null, '#000000');
+  const textFillOpacity = evaluate(fillStyling.fillOpacity, null, null, 1.0);
 
   // Assemble text style options.
   const textStyleOptions = {
     text: labelText,
-    font: `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`,
-    offsetX: Number(offsetX),
-    offsetY: Number(offsetY),
+    font: olFontString,
+    offsetX,
+    offsetY,
     rotation: (Math.PI * labelRotationDegrees) / 180.0,
     textAlign,
     textBaseline,
@@ -173,6 +170,42 @@ function getTextStyle(symbolizer, feature, getProperty) {
   const placement =
     geometryType !== 'point' && lineplacement ? 'line' : 'point';
   olText.setPlacement(placement);
+
+  // Apply dynamic style properties.
+  applyDynamicTextStyling(olStyle, symbolizer, feature, getProperty);
+
+  // Adjust font if one or more font svgparameters are dynamic.
+  if (symbolizer.font && symbolizer.font.styling) {
+    const fontStyling = symbolizer.font.styling || {};
+    if (
+      isDynamicExpression(fontStyling.fontFamily) ||
+      isDynamicExpression(fontStyling.fontStyle) ||
+      isDynamicExpression(fontStyling.fontWeight) ||
+      isDynamicExpression(fontStyling.fontSize)
+    ) {
+      const fontFamily = evaluate(
+        fontStyling.fontFamily,
+        feature,
+        getProperty,
+        'sans-serif'
+      );
+      const fontStyle = evaluate(
+        fontStyling.fontStyle,
+        feature,
+        getProperty,
+        ''
+      );
+      const fontWeight = evaluate(
+        fontStyling.fontWeight,
+        feature,
+        getProperty,
+        ''
+      );
+      const fontSize = evaluate(fontStyling.fontSize, feature, getProperty, 10);
+      const olFontString = `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`;
+      olText.setFont(olFontString);
+    }
+  }
 
   return olStyle;
 }

--- a/src/styles/textStyle.js
+++ b/src/styles/textStyle.js
@@ -1,5 +1,5 @@
 import { Style, Fill, Stroke, Text } from 'ol/style';
-import { hexToRGB, memoizeStyleFunction } from './styleUtils';
+import { getOLColorString, memoizeStyleFunction } from './styleUtils';
 import evaluate, { isDynamicExpression } from '../olEvaluator';
 import { emptyStyle } from './static';
 
@@ -82,6 +82,9 @@ function textStyle(textsymbolizer) {
     textBaseline = 'top';
   }
 
+  const textFillColor = evaluate(fill.fill, null, null, '#000000');
+  const textFillOpacity = evaluate(fill.fillOpacity, null, null, 1.0);
+
   // Assemble text style options.
   const textStyleOptions = {
     text: labelText,
@@ -92,20 +95,17 @@ function textStyle(textsymbolizer) {
     textAlign,
     textBaseline,
     fill: new Fill({
-      color:
-        fill.fillOpacity && fill.fill && fill.fill.slice(0, 1) === '#'
-          ? hexToRGB(fill.fill, fill.fillOpacity)
-          : fill.fill,
+      color: getOLColorString(textFillColor, textFillOpacity),
     }),
   };
+
+  const haloFillColor = evaluate(halo.fill, null, null, '#FFFFFF');
+  const haloFillOpacity = evaluate(halo.fillOpacity, null, null, 1.0);
 
   // Convert SLD halo to text symbol stroke.
   if (textsymbolizer.halo) {
     textStyleOptions.stroke = new Stroke({
-      color:
-        halo.fillOpacity && halo.fill && halo.fill.slice(0, 1) === '#'
-          ? hexToRGB(halo.fill, halo.fillOpacity)
-          : halo.fill,
+      color: getOLColorString(haloFillColor, haloFillOpacity),
       // wrong position width radius equal to 2 or 4
       width:
         (haloRadius === 2 || haloRadius === 4

--- a/src/styles/wellknown.js
+++ b/src/styles/wellknown.js
@@ -17,7 +17,7 @@ function getWellKnownSymbol(
   fill,
   rotationDegrees = 0.0
 ) {
-  const radius = 0.5 * parseFloat(size);
+  const radius = size / 2;
   const rotationRadians = (Math.PI * rotationDegrees) / 180.0;
 
   let fillColor;

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -21,6 +21,8 @@ import { simpleLineSymbolizerSld } from './data/simple-line-symbolizer.sld';
 import { simplePointSymbolizerSld } from './data/simple-point-symbolizer.sld';
 import { emptyPolygonSymbolizerSld } from './data/empty-polygon-symbolizer.sld';
 import { dynamicPolygonSymbolizerSld } from './data/dynamic-polygon-symbolizer.sld';
+import { dynamicLineSymbolizerSld } from './data/dynamic-line-symbolizer.sld';
+import { dynamicPointSymbolizerSld } from './data/dynamic-point-symbolizer.sld';
 import { doubleLineSld } from './data/double-line.sld';
 
 import { IMAGE_LOADING, IMAGE_LOADED } from '../src/constants';
@@ -965,6 +967,35 @@ describe('Styling with dynamic SVG Parameters', () => {
     },
   };
 
+  const lineGeoJSON = {
+    type: 'Feature',
+    geometry: {
+      type: 'LineString',
+      // prettier-ignore
+      coordinates: [[0, 0], [0, 100], [100, 100], [100, 0], [0, 0]],
+    },
+    properties: {
+      myStrokeWidth: 3,
+      myStrokeColor: '#646464',
+      myStrokeOpacity: 0.4,
+    },
+  };
+
+  const pointGeoJSON = {
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [0, 0],
+    },
+    properties: {
+      myStrokeWidth: 3,
+      myStrokeColor: '#223344',
+      myStrokeOpacity: 1.0,
+      myFillColor: '#646464', // [100, 100, 100]
+      myFillOpacity: 0.4,
+    },
+  };
+
   describe('Default values for SVG style params', () => {
     let olStroke;
     let olFill;
@@ -1031,6 +1062,54 @@ describe('Styling with dynamic SVG Parameters', () => {
 
     it('Dynamic partially transparent fill color (transparency encoded in color string))', () => {
       expect(olStyle.getFill().getColor()).to.equal('rgba(100, 100, 100, 0.4)');
+    });
+  });
+
+  describe('Dynamic line styling', () => {
+    let olStyle;
+    before(() => {
+      const fmtGeoJSON = new OLFormatGeoJSON();
+      const polygonFeature = fmtGeoJSON.readFeature(lineGeoJSON);
+      const sldObject = Reader(dynamicLineSymbolizerSld);
+      const [featureTypeStyle] =
+        sldObject.layers[0].styles[0].featuretypestyles;
+      const styleFunction = createOlStyleFunction(featureTypeStyle);
+      olStyle = styleFunction(polygonFeature)[0];
+    });
+
+    it('Dynamic stroke width', () => {
+      expect(olStyle.getStroke().getWidth()).to.equal(3);
+    });
+
+    it('Dynamic stroke color (transparency encoded in color string)', () => {
+      expect(olStyle.getStroke().getColor()).to.equal(
+        'rgba(100, 100, 100, 0.4)'
+      );
+    });
+  });
+
+  describe('Dynamic point graphic mark styling', () => {
+    let olStyle;
+    before(() => {
+      const fmtGeoJSON = new OLFormatGeoJSON();
+      const pointFeature = fmtGeoJSON.readFeature(pointGeoJSON);
+      const sldObject = Reader(dynamicPointSymbolizerSld);
+      const [featureTypeStyle] =
+        sldObject.layers[0].styles[0].featuretypestyles;
+      const styleFunction = createOlStyleFunction(featureTypeStyle);
+      olStyle = styleFunction(pointFeature)[0];
+    });
+
+    it('Dynamic stroke width', () => {
+      expect(olStyle.getImage().getStroke().getWidth()).to.equal(3);
+    });
+
+    it('Dynamic stroke color (opacity 1 --> hex string)', () => {
+      expect(olStyle.getImage().getStroke().getColor()).to.equal('#223344');
+    });
+
+    it('Dynamic partially transparent fill color (transparency encoded in color string))', () => {
+      expect(olStyle.getImage().getFill().getColor()).to.equal('rgba(100, 100, 100, 0.4)');
     });
   });
 });

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -19,6 +19,7 @@ import { externalGraphicStrokeSld } from './data/external-graphicstroke.sld';
 import { polyGraphicFillAndStrokeSld } from './data/poly-graphic-fill-and-stroke';
 import { simpleLineSymbolizerSld } from './data/simple-line-symbolizer.sld';
 import { simplePointSymbolizerSld } from './data/simple-point-symbolizer.sld';
+import { emptyPolygonSymbolizerSld } from './data/empty-polygon-symbolizer.sld';
 import { doubleLineSld } from './data/double-line.sld';
 
 import { IMAGE_LOADING, IMAGE_LOADED } from '../src/constants';
@@ -943,5 +944,67 @@ describe('Static style extraction with getOlStyle', () => {
     const [featureTypeStyle] = sldObject.layers[0].styles[0].featuretypestyles;
     const olStyles = createOlStyle(featureTypeStyle.rules[0]);
     expect(olStyles.length).to.equal(0);
+  });
+});
+
+describe('Styling with dynamic SVG Parameters', () => {
+  const geojson = {
+    type: 'Feature',
+    geometry: {
+      type: 'Polygon',
+      // prettier-ignore
+      coordinates: [[[0, 0], [0, 100], [100, 100], [100, 0], [0, 0]]],
+    },
+    properties: {
+      myStrokeWidth: 3,
+      myStrokeColor: '#223344',
+      myStrokeOpacity: 0.8,
+      myFillColor: 'hotpink',
+      myFillOpacity: 0.4,
+    },
+  };
+
+  describe('Default values for SVG style params', () => {
+    let olStroke;
+    let olFill;
+    before(() => {
+      const fmtGeoJSON = new OLFormatGeoJSON();
+      const polygonFeature = fmtGeoJSON.readFeature(geojson);
+      const sldObject = Reader(emptyPolygonSymbolizerSld);
+      const [featureTypeStyle] =
+        sldObject.layers[0].styles[0].featuretypestyles;
+      const styleFunction = createOlStyleFunction(featureTypeStyle);
+      const olStyle = styleFunction(polygonFeature)[0];
+      olStroke = olStyle.getStroke();
+      olFill = olStyle.getFill();
+    });
+
+    it('Default fill color should be gray with opacity 1', () => {
+      expect(olFill.getColor()).to.equal('#808080');
+    });
+
+    it('Default stroke width should be 1', () => {
+      expect(olStroke.getWidth()).to.equal(1);
+    });
+
+    it('Default stroke color should be black', () => {
+      expect(olStroke.getColor()).to.equal('black');
+    });
+
+    it('Default stroke line dash offset should be 0', () => {
+      expect(olStroke.getLineDashOffset()).to.equal(0);
+    });
+
+    it('Default stroke line dash shoule be null', () => {
+      expect(olStroke.getLineDash()).to.be.null;
+    });
+
+    it('Default stroke line cap should be undefined', () => {
+      expect(olStroke.getLineCap()).to.be.undefined;
+    });
+
+    it('Default stroke line join should be undefined', () => {
+      expect(olStroke.getLineJoin()).to.be.undefined;
+    });
   });
 });

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -24,6 +24,7 @@ import { emptySvgParametersSld } from './data/empty-svg-parameters.sld';
 import { dynamicPolygonSymbolizerSld } from './data/dynamic-polygon-symbolizer.sld';
 import { dynamicLineSymbolizerSld } from './data/dynamic-line-symbolizer.sld';
 import { dynamicPointSymbolizerSld } from './data/dynamic-point-symbolizer.sld';
+import { dynamicTextSymbolizerSld } from './data/dynamic-text-symbolizer.sld';
 import { doubleLineSld } from './data/double-line.sld';
 
 import { IMAGE_LOADING, IMAGE_LOADED } from '../src/constants';
@@ -1027,6 +1028,25 @@ describe('Styling with dynamic SVG Parameters', () => {
     },
   };
 
+  const pointTextGeoJSON = {
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [0, 0],
+    },
+    properties: {
+      myTextColor: '#646464', // [100, 100, 100]
+      myTextOpacity: 0.4,
+      myHaloColor: '#C8C8C8', // [200, 200, 200]
+      myHaloOpacity: 0.5,
+      myHaloRadius: 3,
+      myFontFamily: 'Comic Sans MS',
+      myFontSize: '14',
+      myFontStyle: 'italic',
+      myFontWeight: 'bold',
+    },
+  };
+
   describe('Default values for missing SVG style params', () => {
     let olStroke;
     let olFill;
@@ -1187,6 +1207,38 @@ describe('Styling with dynamic SVG Parameters', () => {
       expect(olStyle.getImage().getFill().getColor()).to.equal(
         'rgba(100, 100, 100, 0.4)'
       );
+    });
+  });
+
+  describe('Dynamic text symbolizer styling', () => {
+    let olText;
+    before(() => {
+      const fmtGeoJSON = new OLFormatGeoJSON();
+      const pointTextFeature = fmtGeoJSON.readFeature(pointTextGeoJSON);
+      const sldObject = Reader(dynamicTextSymbolizerSld);
+      const [featureTypeStyle] =
+        sldObject.layers[0].styles[0].featuretypestyles;
+      const styleFunction = createOlStyleFunction(featureTypeStyle);
+      const olStyle = styleFunction(pointTextFeature)[0];
+      olText = olStyle.getText();
+    });
+
+    it('Dynamic partially transparent text color (transparency encoded in color string))', () => {
+      expect(olText.getStroke().getColor()).to.equal(
+        'rgba(100, 100, 100, 0.4)'
+      );
+    });
+
+    it('Dynamic partially transparent halo color (transparency encoded in color string))', () => {
+      expect(olText.getFill().getColor()).to.equal('rgba(200, 200, 200, 0.5)');
+    });
+
+    it('Dynamic text halo radius', () => {
+      expect(olText.getStroke().getWidth()).to.equal(6); // Stroke width equals twice halo radius.
+    });
+
+    it('Dynamic font style', () => {
+      expect(olText.getFont()).to.equal('italic bold 14px Comic Sans MS');
     });
   });
 });

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -449,6 +449,18 @@ describe('SVG style parameters', () => {
     it('Stroke width should be number', () => {
       expect(strokeStyle.strokeWidth).to.equal(4);
     });
+    it('Stroke linejoin should be string', () => {
+      expect(strokeStyle.strokeLinejoin).to.equal('bevel');
+    });
+    it('Stroke linecap should be string', () => {
+      expect(strokeStyle.strokeLinecap).to.equal('square');
+    });
+    it('Stroke dasharray should be string', () => {
+      expect(strokeStyle.strokeDasharray).to.equal('6 10');
+    });
+    it('Stroke dashoffset should be number', () => {
+      expect(strokeStyle.strokeDashoffset).to.equal(4);
+    });
   });
 
   describe('Dynamic SVG parameters', () => {

--- a/test/data/dynamic-line-symbolizer.sld.js
+++ b/test/data/dynamic-line-symbolizer.sld.js
@@ -1,0 +1,30 @@
+export const dynamicLineSymbolizerSld = `<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd"
+  xmlns:se="http://www.opengis.net/se">
+  <NamedLayer>
+    <UserStyle>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:LineSymbolizer>
+            <se:Stroke>
+              <se:SvgParameter name="stroke">
+                <ogc:PropertyName>myStrokeColor</ogc:PropertyName>
+              </se:SvgParameter>
+              <se:SvgParameter name="stroke-opacity">
+                <ogc:PropertyName>myStrokeOpacity</ogc:PropertyName>
+              </se:SvgParameter>
+              <se:SvgParameter name="stroke-width">
+                <ogc:PropertyName>myStrokeWidth</ogc:PropertyName>
+              </se:SvgParameter>
+            </se:Stroke>
+          </se:LineSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>`;
+
+export default dynamicLineSymbolizerSld;

--- a/test/data/dynamic-point-symbolizer.sld.js
+++ b/test/data/dynamic-point-symbolizer.sld.js
@@ -1,0 +1,44 @@
+export const dynamicPointSymbolizerSld = `<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd"
+  xmlns:se="http://www.opengis.net/se">
+  <NamedLayer>
+    <UserStyle>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:PointSymbolizer>
+          <se:Graphic>
+            <se:Mark>
+              <se:WellKnownName>square</se:WellKnownName>
+              <se:Fill>
+                <se:SvgParameter name="fill">
+                  <ogc:PropertyName>myFillColor</ogc:PropertyName>
+                </se:SvgParameter>
+                <se:SvgParameter name="fill-opacity">
+                  <ogc:PropertyName>myFillOpacity</ogc:PropertyName>
+                </se:SvgParameter>
+              </se:Fill>
+              <se:Stroke>
+                <se:SvgParameter name="stroke">
+                  <ogc:PropertyName>myStrokeColor</ogc:PropertyName>
+                </se:SvgParameter>
+                <se:SvgParameter name="stroke-opacity">
+                  <ogc:PropertyName>myStrokeOpacity</ogc:PropertyName>
+                </se:SvgParameter>
+                <se:SvgParameter name="stroke-width">
+                  <ogc:PropertyName>myStrokeWidth</ogc:PropertyName>
+                </se:SvgParameter>
+              </se:Stroke>
+              </se:Mark>
+            <se:Size>10</se:Size>
+          </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>`;
+
+export default dynamicPointSymbolizerSld;

--- a/test/data/dynamic-text-symbolizer.sld.js
+++ b/test/data/dynamic-text-symbolizer.sld.js
@@ -1,0 +1,65 @@
+export const dynamicTextSymbolizerSld = `<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd"
+  xmlns:se="http://www.opengis.net/se">
+  <NamedLayer>
+    <UserStyle>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:TextSymbolizer>
+            <se:Label>
+              <ogc:PropertyName>myLabel</ogc:PropertyName>
+            </se:Label>
+            <se:Font>
+              <se:SvgParameter name="font-family">
+                <ogc:PropertyName>myFontFamily</ogc:PropertyName>
+              </se:SvgParameter>
+              <se:SvgParameter name="font-style">
+                <ogc:PropertyName>myFontStyle</ogc:PropertyName>
+              </se:SvgParameter>
+              <se:SvgParameter name="font-weight">
+                <ogc:PropertyName>myFontWeight</ogc:PropertyName>
+              </se:SvgParameter>
+              <se:SvgParameter name="font-size">
+                <ogc:PropertyName>myFontSize</ogc:PropertyName>
+              </se:SvgParameter>
+            </se:Font>
+            <se:LabelPlacement>
+              <se:PointPlacement>
+                <se:AnchorPoint>
+                  <se:AnchorPointX>0.5</se:AnchorPointX>
+                  <se:AnchorPointY>0.5</se:AnchorPointY>
+                </se:AnchorPoint>
+              </se:PointPlacement>
+            </se:LabelPlacement>
+            <se:Halo>
+              <se:Radius>
+                <ogc:PropertyName>myHaloRadius</ogc:PropertyName>
+              </se:Radius>
+              <se:Fill>
+                <se:SvgParameter name="fill">
+                  <ogc:PropertyName>myHaloColor</ogc:PropertyName>
+                </se:SvgParameter>
+                <se:SvgParameter name="fill-opacity">
+                  <ogc:PropertyName>myHaloOpacity</ogc:PropertyName>
+                </se:SvgParameter>
+              </se:Fill>
+            </se:Halo>
+            <se:Fill>
+              <se:SvgParameter name="fill">
+                <ogc:PropertyName>myTextColor</ogc:PropertyName>
+              </se:SvgParameter>
+              <se:SvgParameter name="fill-opacity">
+                <ogc:PropertyName>myTextOpacity</ogc:PropertyName>
+              </se:SvgParameter>
+            </se:Fill>
+          </se:TextSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>`;
+
+export default dynamicTextSymbolizerSld;

--- a/test/data/empty-polygon-symbolizer.sld.js
+++ b/test/data/empty-polygon-symbolizer.sld.js
@@ -1,0 +1,23 @@
+export const emptyPolygonSymbolizerSld = `<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd"
+  xmlns:se="http://www.opengis.net/se">
+  <NamedLayer>
+    <UserStyle>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:PolygonSymbolizer>
+            <se:Fill>
+            </se:Fill>
+            <se:Stroke>
+            </se:Stroke>
+          </se:PolygonSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>`;
+
+export default emptyPolygonSymbolizerSld;

--- a/test/data/empty-svg-parameters.sld.js
+++ b/test/data/empty-svg-parameters.sld.js
@@ -1,0 +1,32 @@
+export const emptySvgParametersSld = `<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd"
+  xmlns:se="http://www.opengis.net/se">
+  <NamedLayer>
+    <UserStyle>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:PolygonSymbolizer>
+            <se:Fill>
+              <se:SvgParameter name="fill"></se:SvgParameter>
+              <se:SvgParameter name="fill-opacity"></se:SvgParameter>
+            </se:Fill>
+            <se:Stroke>
+              <se:SvgParameter name="stroke"></se:SvgParameter>
+              <se:SvgParameter name="stroke-opacity"></se:SvgParameter>
+              <se:SvgParameter name="stroke-width"></se:SvgParameter>
+              <se:SvgParameter name="stroke-linejoin"></se:SvgParameter>
+              <se:SvgParameter name="stroke-linecap"></se:SvgParameter>
+              <se:SvgParameter name="stroke-dasharray"></se:SvgParameter>
+              <se:SvgParameter name="stroke-dashoffset"></se:SvgParameter>
+            </se:Stroke>
+          </se:PolygonSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>`;
+
+export default emptySvgParametersSld;

--- a/test/data/static-polygon-symbolizer.sld.js
+++ b/test/data/static-polygon-symbolizer.sld.js
@@ -17,6 +17,10 @@ export const staticPolygonSymbolizerSld = `<?xml version="1.0" encoding="UTF-8"?
               <se:SvgParameter name="stroke">#00FF00</se:SvgParameter>
               <se:SvgParameter name="stroke-opacity">1.0</se:SvgParameter>
               <se:SvgParameter name="stroke-width">4</se:SvgParameter>
+              <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+              <se:SvgParameter name="stroke-linecap">square</se:SvgParameter>
+              <se:SvgParameter name="stroke-dasharray">6 10</se:SvgParameter>
+              <se:SvgParameter name="stroke-dashoffset">4</se:SvgParameter>
             </se:Stroke>
           </se:PolygonSymbolizer>
         </se:Rule>

--- a/test/olEvaluator.test.js
+++ b/test/olEvaluator.test.js
@@ -47,6 +47,7 @@ describe('Expression evaluation', () => {
   it('Compound filter expression', () => {
     const expression = {
       type: 'expression',
+      typeHint: 'number',
       children: [
         {
           type: 'literal',
@@ -58,7 +59,7 @@ describe('Expression evaluation', () => {
         },
       ],
     };
-    expect(evaluate(expression, feature, getProperty)).to.equal('-42');
+    expect(evaluate(expression, feature, getProperty)).to.equal(-42);
   });
 
   it('Custom property getter', () => {
@@ -95,8 +96,8 @@ describe('Expression evaluation', () => {
         expect(evaluate(0, null, null, 42)).to.equal(0);
       });
 
-      it('Do not use default value when expression is empty string', () => {
-        expect(evaluate('', null, null, 42)).to.equal('');
+      it('Use default value when expression is empty string', () => {
+        expect(evaluate('', null, null, '42')).to.equal('42');
       });
     });
 
@@ -111,6 +112,10 @@ describe('Expression evaluation', () => {
         };
         return evaluate(testExpression, testFeature, testGetter, defaultValue);
       }
+
+      it('Use default value when feature is null', () => {
+        expect(readValueProperty(null, 42, 'number')).to.equal(42);
+      });
 
       it('Use default value when feature property equals null', () => {
         expect(
@@ -164,7 +169,20 @@ describe('Expression evaluation', () => {
         ).to.equal(42);
       });
 
-      it('When typeHint is string, do not use default when feature property is an empty string', () => {
+      it('When typeHint is number, use default value when feature property is an invalid numeric string', () => {
+        expect(
+          readValueProperty(
+            {
+              type: 'Feature',
+              properties: { value: '3,50€' },
+            },
+            42,
+            'number'
+          )
+        ).to.equal(42);
+      });
+
+      it('When typeHint is string, use default value when feature property is an empty string', () => {
         expect(
           readValueProperty(
             {
@@ -174,7 +192,7 @@ describe('Expression evaluation', () => {
             'DEFAULT',
             'string'
           )
-        ).to.equal('');
+        ).to.equal('DEFAULT');
       });
     });
   });


### PR DESCRIPTION
This branch enables dynamic (`ogc:PropertyName`) values for style properties (`SvgParameter`) inside symbolizers.

Note: this does not work for Marks inside a GraphicStroke or GraphicFill.