### PR TITLE
Correctly handle zero opacity

### DIFF
--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -1634,7 +1634,7 @@
     var r = parseInt(hex.slice(1, 3), 16);
     var g = parseInt(hex.slice(3, 5), 16);
     var b = parseInt(hex.slice(5, 7), 16);
-    if (alpha) {
+    if (alpha || alpha === 0) {
       return ("rgba(" + r + ", " + g + ", " + b + ", " + alpha + ")");
     }
     return ("rgb(" + r + ", " + g + ", " + b + ")");

--- a/src/styles/styleUtils.js
+++ b/src/styles/styleUtils.js
@@ -36,7 +36,7 @@ function hexToRGB(hex, alpha) {
   const r = parseInt(hex.slice(1, 3), 16);
   const g = parseInt(hex.slice(3, 5), 16);
   const b = parseInt(hex.slice(5, 7), 16);
-  if (alpha) {
+  if (alpha || alpha === 0) {
     return `rgba(${r}, ${g}, ${b}, ${alpha})`;
   }
   return `rgb(${r}, ${g}, ${b})`;

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -1160,6 +1160,25 @@ describe('Styling with dynamic SVG Parameters', () => {
     });
   });
 
+  describe('Zero opacity', () => {
+    it('Opacity 0 should not default to fully opaque', () => {
+      const polygonGeoJSON2 = JSON.parse(JSON.stringify(polygonGeoJSON));
+      polygonGeoJSON2.properties.myFillOpacity = 0.0;
+      polygonGeoJSON2.properties.myStrokeOpacity = 0.0;
+      const fmtGeoJSON = new OLFormatGeoJSON();
+      const polygonFeature = fmtGeoJSON.readFeature(polygonGeoJSON2);
+      const sldObject = Reader(dynamicPolygonSymbolizerSld);
+      const [featureTypeStyle] =
+        sldObject.layers[0].styles[0].featuretypestyles;
+      const styleFunction = createOlStyleFunction(featureTypeStyle);
+      const olStyle = styleFunction(polygonFeature)[0];
+      const fillColor = olStyle.getFill().getColor();
+      expect(fillColor).to.equal('rgba(100, 100, 100, 0)');
+      const strokeColor = olStyle.getStroke().getColor();
+      expect(strokeColor).to.equal('rgba(34, 51, 68, 0)');
+    });
+  });
+
   describe('Dynamic line styling', () => {
     let olStyle;
     before(() => {

--- a/test/styleUtils.test.js
+++ b/test/styleUtils.test.js
@@ -1,6 +1,9 @@
 /* global describe it expect */
 
-import { calculateGraphicSpacing } from '../src/styles/styleUtils';
+import {
+  calculateGraphicSpacing,
+  getOLColorString,
+} from '../src/styles/styleUtils';
 
 describe('Style utils', () => {
   describe('Calculate graphic spacing', () => {
@@ -54,6 +57,10 @@ describe('Style utils', () => {
         },
       };
       expect(calculateGraphicSpacing(symbolizer, 10)).to.equal(30);
+    });
+
+    it('Handle zero opacity color', () => {
+      expect(getOLColorString('#646464', 0)).to.equal('rgba(100, 100, 100, 0)');
     });
   });
 });


### PR DESCRIPTION
This PR fixes a bug where opacity values of 0 are dropped from the rgba color value, defaulting to opacity 1.