### PR TITLE
Add support for graphic displacement

### DIFF
--- a/docs/assets/sld-benelux.xml
+++ b/docs/assets/sld-benelux.xml
@@ -32,6 +32,17 @@
               </Rotation>
             </Graphic>
           </PointSymbolizer>
+          <PointSymbolizer>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#FF0000</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>6</Size>
+            </Graphic>
+          </PointSymbolizer>
         </Rule>
         <Rule>
           <Name>be</Name>
@@ -56,6 +67,17 @@
               </Rotation>
             </Graphic>
           </PointSymbolizer>
+          <PointSymbolizer>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#FF0000</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>6</Size>
+            </Graphic>
+          </PointSymbolizer>
         </Rule>
         <Rule>
           <Name>lu</Name>
@@ -78,6 +100,21 @@
               <Rotation>
                 <ogc:PropertyName>angle</ogc:PropertyName>
               </Rotation>
+              <Displacement>
+                <DisplacementX>0</DisplacementX>
+                <DisplacementY>12</DisplacementY>
+              </Displacement>
+            </Graphic>
+          </PointSymbolizer>
+          <PointSymbolizer>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#FF0000</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>6</Size>
             </Graphic>
           </PointSymbolizer>
         </Rule>

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -3436,7 +3436,8 @@
         ? pointplacement.displacement
         : {};
     var offsetX = evaluate(displacement.displacementx, null, null, 0.0);
-    var offsetY = evaluate(displacement.displacementy, null, null, 0.0);
+    // Positive offsetY shifts the label downwards. Positive displacementY in SLD means shift upwards.
+    var offsetY = -evaluate(displacement.displacementy, null, null, 0.0);
 
     // OpenLayers does not support fractional alignment, so snap the anchor to the most suitable option.
     var anchorpoint = (pointplacement && pointplacement.anchorpoint) || {};

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -2575,6 +2575,23 @@
       olImage.setRotation(rotationRadians);
     }
 
+    // Update displacement
+    var displacement = graphic.displacement;
+    if (displacement) {
+      var displacementx = displacement.displacementx;
+      var displacementy = displacement.displacementy;
+      if (
+        typeof displacementx !== 'undefined' ||
+        typeof displacementy !== 'undefined'
+      ) {
+        var dx = evaluate(displacementx, feature, getProperty) || 0.0;
+        var dy = evaluate(displacementy, feature, getProperty) || 0.0;
+        if (dx !== 0.0 || dy !== 0.0) {
+          olImage.setDisplacement([dx, dy]);
+        }
+      }
+    }
+
     // --- Update stroke and fill ---
     if (graphic.mark) {
       var strokeChanged = applyDynamicStrokeStyling(

--- a/src/styles/pointStyle.js
+++ b/src/styles/pointStyle.js
@@ -157,6 +157,22 @@ function getPointStyle(symbolizer, feature, getProperty) {
     olImage.setRotation(rotationRadians);
   }
 
+  // Update displacement
+  const { displacement } = graphic;
+  if (displacement) {
+    const { displacementx, displacementy } = displacement;
+    if (
+      typeof displacementx !== 'undefined' ||
+      typeof displacementy !== 'undefined'
+    ) {
+      const dx = evaluate(displacementx, feature, getProperty) || 0.0;
+      const dy = evaluate(displacementy, feature, getProperty) || 0.0;
+      if (dx !== 0.0 || dy !== 0.0) {
+        olImage.setDisplacement([dx, dy]);
+      }
+    }
+  }
+
   // --- Update stroke and fill ---
   if (graphic.mark) {
     const strokeChanged = applyDynamicStrokeStyling(

--- a/src/styles/textStyle.js
+++ b/src/styles/textStyle.js
@@ -49,7 +49,8 @@ function textStyle(textsymbolizer) {
       ? pointplacement.displacement
       : {};
   const offsetX = evaluate(displacement.displacementx, null, null, 0.0);
-  const offsetY = evaluate(displacement.displacementy, null, null, 0.0);
+  // Positive offsetY shifts the label downwards. Positive displacementY in SLD means shift upwards.
+  const offsetY = -evaluate(displacement.displacementy, null, null, 0.0);
 
   // OpenLayers does not support fractional alignment, so snap the anchor to the most suitable option.
   const anchorpoint = (pointplacement && pointplacement.anchorpoint) || {};

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -773,6 +773,16 @@ describe('Text symbolizer', () => {
     // CDATA whitespace should be kept intact.
     expect(textStyle.getText().getText()).to.equal('Size: 100\nAngle: 42');
   });
+
+  it('Labal displacement', () => {
+    const sldObject = Reader(textSymbolizerSld);
+    const [featureTypeStyle] = sldObject.layers[0].styles[0].featuretypestyles;
+    const styleFunction = createOlStyleFunction(featureTypeStyle);
+    const textStyle = styleFunction(pointFeature)[0];
+    expect(textStyle.getText().getOffsetX()).to.equal(10);
+    // OpenLayers Y offset is inverted. Negative offset shifts upwards.
+    expect(textStyle.getText().getOffsetY()).to.equal(-20);
+  });
 });
 
 describe('Polygon styling', () => {

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -593,6 +593,8 @@ describe('Dynamic style properties', () => {
       properties: {
         size: 100,
         angle: 42,
+        displacementX: 10,
+        displacementY: 20,
         title: 'This is a test',
       },
     };
@@ -624,6 +626,11 @@ describe('Dynamic style properties', () => {
         expect(style.getImage().getRotation()).to.equal(
           (Math.PI * 42.0) / 180.0
         );
+      });
+
+      it('Reads displacement from feature', () => {
+        const style = styleFunction(pointFeature)[0];
+        expect(style.getImage().getDisplacement()).to.deep.equal([10, 20]);
       });
 
       it('Reads text for label from feature', () => {

--- a/test/data/dynamic.sld.js
+++ b/test/data/dynamic.sld.js
@@ -28,6 +28,14 @@ export const dynamicSld = `<?xml version="1.0" encoding="UTF-8"?>
               <sld:Rotation>
                 <ogc:PropertyName>angle</ogc:PropertyName>
               </sld:Rotation>
+              <sld:Displacement>
+                <sld:DisplacementX>
+                  <ogc:PropertyName>displacementX</ogc:PropertyName>
+                </sld:DisplacementX>
+                <sld:DisplacementY>
+                  <ogc:PropertyName>displacementY</ogc:PropertyName>
+                </sld:DisplacementY>
+              </sld:Displacement>
             </sld:Graphic>
           </sld:PointSymbolizer>
           <sld:TextSymbolizer>

--- a/test/data/textSymbolizer.sld.js
+++ b/test/data/textSymbolizer.sld.js
@@ -18,6 +18,10 @@ export const textSymbolizerSld = `<?xml version="1.0" encoding="UTF-8"?>
                   <AnchorPointX>0</AnchorPointX>
                   <AnchorPointY>1</AnchorPointY>
                 </AnchorPoint>
+                <Displacement>
+                  <DisplacementX>10</DisplacementX>
+                  <DisplacementY>20</DisplacementY>
+                </Displacement>
               </PointPlacement>
             </LabelPlacement>
           </TextSymbolizer>


### PR DESCRIPTION
This branch adds support for `Displacement` inside `Graphic` elements.

Also included is a fix for `DisplacementY` for text labels: positive displacement now shifts the label upwards instead of downwards.