### PR TITLE
Fix dynamic style values

### DIFF
--- a/docs/assets/dynamic-styling.js
+++ b/docs/assets/dynamic-styling.js
@@ -97,6 +97,7 @@ for (let k = 0; k < numFeatures; k += 1) {
         myStrokeColor: weightedRandomColor(0, 0, 128),
         myStrokeWidth: 1 + 3 * Math.random(),
         myStrokeOpacity: 0.8 + 0.2 * Math.random(),
+        myAngle: 360.0 * Math.random(),
       },
     };
     randomGeoJSON.features.push(randomPolygonFeature);

--- a/docs/assets/dynamic-styling.js
+++ b/docs/assets/dynamic-styling.js
@@ -44,6 +44,7 @@ for (let k = 0; k < numFeatures; k += 1) {
         myStrokeColor: weightedRandomColor(128, 0, 0),
         myStrokeWidth: 1 + 3 * Math.random(),
         myStrokeOpacity: 0.8 + 0.2 * Math.random(),
+        myRotation: 360.0 * Math.random(),
       },
     };
     randomGeoJSON.features.push(randomPointFeature);
@@ -97,7 +98,6 @@ for (let k = 0; k < numFeatures; k += 1) {
         myStrokeColor: weightedRandomColor(0, 0, 128),
         myStrokeWidth: 1 + 3 * Math.random(),
         myStrokeOpacity: 0.8 + 0.2 * Math.random(),
-        myAngle: 360.0 * Math.random(),
       },
     };
     randomGeoJSON.features.push(randomPolygonFeature);

--- a/docs/assets/sld-dynamic-styling.xml
+++ b/docs/assets/sld-dynamic-styling.xml
@@ -43,6 +43,9 @@
               <se:Size>
                 <ogc:PropertyName>mySize</ogc:PropertyName>
               </se:Size>
+              <se:Rotation>
+                <ogc:PropertyName>myRotation</ogc:PropertyName>
+              </se:Rotation>
             </se:Graphic>
           </se:PointSymbolizer>
         </se:Rule>

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -2575,23 +2575,6 @@
       olImage.setRotation(rotationRadians);
     }
 
-    // Update displacement
-    var displacement = graphic.displacement;
-    if (displacement) {
-      var displacementx = displacement.displacementx;
-      var displacementy = displacement.displacementy;
-      if (
-        typeof displacementx !== 'undefined' ||
-        typeof displacementy !== 'undefined'
-      ) {
-        var dx = evaluate(displacementx, feature, getProperty) || 0.0;
-        var dy = evaluate(displacementy, feature, getProperty) || 0.0;
-        if (dx !== 0.0 || dy !== 0.0) {
-          olImage.setDisplacement([dx, dy]);
-        }
-      }
-    }
-
     // --- Update stroke and fill ---
     if (graphic.mark) {
       var strokeChanged = applyDynamicStrokeStyling(
@@ -2619,6 +2602,23 @@
           olImage.getFill()
         );
         olStyle.setImage(olImage);
+      }
+    }
+
+    // Update displacement
+    var displacement = graphic.displacement;
+    if (displacement) {
+      var displacementx = displacement.displacementx;
+      var displacementy = displacement.displacementy;
+      if (
+        typeof displacementx !== 'undefined' ||
+        typeof displacementy !== 'undefined'
+      ) {
+        var dx = evaluate(displacementx, feature, getProperty) || 0.0;
+        var dy = evaluate(displacementy, feature, getProperty) || 0.0;
+        if (dx !== 0.0 || dy !== 0.0) {
+          olImage.setDisplacement([dx, dy]);
+        }
       }
     }
 

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -2538,13 +2538,18 @@
 
     // Apply dynamic values to the cached OL style instance before returning it.
 
-    // --- Update dynamic size ---
     var graphic = symbolizer.graphic;
-    var size = graphic.size;
-    if (isDynamicExpression(size)) {
-      var sizeValue =
-        Number(evaluate(size, feature, getProperty)) || DEFAULT_MARK_SIZE;
 
+    // Calculate size and rotation values first.
+    var size = graphic.size;
+    var rotation = graphic.rotation;
+    var sizeValue =
+      Number(evaluate(size, feature, getProperty)) || DEFAULT_MARK_SIZE;
+    var rotationDegrees =
+      Number(evaluate(rotation, feature, getProperty)) || 0.0;
+
+    // --- Update dynamic size ---
+    if (isDynamicExpression(size)) {
       if (graphic.externalgraphic && graphic.externalgraphic.onlineresource) {
         var height = olImage.getSize()[1];
         var scale = sizeValue / height || 1;
@@ -2559,17 +2564,15 @@
           sizeValue,
           // Note: re-use stroke and fill instances for a (small?) performance gain.
           olImage.getStroke(),
-          olImage.getFill()
+          olImage.getFill(),
+          rotationDegrees
         );
         olStyle.setImage(olImage);
       }
     }
 
     // --- Update dynamic rotation ---
-    var rotation = graphic.rotation;
     if (isDynamicExpression(rotation)) {
-      var rotationDegrees =
-        Number(evaluate(rotation, feature, getProperty)) || 0.0;
       // Note: OL angles are in radians.
       var rotationRadians = (Math.PI * rotationDegrees) / 180.0;
       olImage.setRotation(rotationRadians);
@@ -2593,13 +2596,12 @@
 
       if (strokeChanged || fillChanged) {
         // Create a new olImage in order to force a re-render to see the style changes.
-        var sizeValue$1 =
-          Number(evaluate(size, feature, getProperty)) || DEFAULT_MARK_SIZE;
         olImage = getWellKnownSymbol(
           (graphic.mark && graphic.mark.wellknownname) || 'square',
-          sizeValue$1,
+          sizeValue,
           olImage.getStroke(),
-          olImage.getFill()
+          olImage.getFill(),
+          rotationDegrees
         );
         olStyle.setImage(olImage);
       }

--- a/src/styles/pointStyle.js
+++ b/src/styles/pointStyle.js
@@ -120,13 +120,17 @@ function getPointStyle(symbolizer, feature, getProperty) {
 
   // Apply dynamic values to the cached OL style instance before returning it.
 
-  // --- Update dynamic size ---
   const { graphic } = symbolizer;
-  const { size } = graphic;
-  if (isDynamicExpression(size)) {
-    const sizeValue =
-      Number(evaluate(size, feature, getProperty)) || DEFAULT_MARK_SIZE;
 
+  // Calculate size and rotation values first.
+  const { size, rotation } = graphic;
+  const sizeValue =
+    Number(evaluate(size, feature, getProperty)) || DEFAULT_MARK_SIZE;
+  const rotationDegrees =
+    Number(evaluate(rotation, feature, getProperty)) || 0.0;
+
+  // --- Update dynamic size ---
+  if (isDynamicExpression(size)) {
     if (graphic.externalgraphic && graphic.externalgraphic.onlineresource) {
       const height = olImage.getSize()[1];
       const scale = sizeValue / height || 1;
@@ -141,17 +145,15 @@ function getPointStyle(symbolizer, feature, getProperty) {
         sizeValue,
         // Note: re-use stroke and fill instances for a (small?) performance gain.
         olImage.getStroke(),
-        olImage.getFill()
+        olImage.getFill(),
+        rotationDegrees
       );
       olStyle.setImage(olImage);
     }
   }
 
   // --- Update dynamic rotation ---
-  const { rotation } = graphic;
   if (isDynamicExpression(rotation)) {
-    const rotationDegrees =
-      Number(evaluate(rotation, feature, getProperty)) || 0.0;
     // Note: OL angles are in radians.
     const rotationRadians = (Math.PI * rotationDegrees) / 180.0;
     olImage.setRotation(rotationRadians);
@@ -175,13 +177,12 @@ function getPointStyle(symbolizer, feature, getProperty) {
 
     if (strokeChanged || fillChanged) {
       // Create a new olImage in order to force a re-render to see the style changes.
-      const sizeValue =
-        Number(evaluate(size, feature, getProperty)) || DEFAULT_MARK_SIZE;
       olImage = getWellKnownSymbol(
         (graphic.mark && graphic.mark.wellknownname) || 'square',
         sizeValue,
         olImage.getStroke(),
-        olImage.getFill()
+        olImage.getFill(),
+        rotationDegrees
       );
       olStyle.setImage(olImage);
     }

--- a/src/styles/pointStyle.js
+++ b/src/styles/pointStyle.js
@@ -157,22 +157,6 @@ function getPointStyle(symbolizer, feature, getProperty) {
     olImage.setRotation(rotationRadians);
   }
 
-  // Update displacement
-  const { displacement } = graphic;
-  if (displacement) {
-    const { displacementx, displacementy } = displacement;
-    if (
-      typeof displacementx !== 'undefined' ||
-      typeof displacementy !== 'undefined'
-    ) {
-      const dx = evaluate(displacementx, feature, getProperty) || 0.0;
-      const dy = evaluate(displacementy, feature, getProperty) || 0.0;
-      if (dx !== 0.0 || dy !== 0.0) {
-        olImage.setDisplacement([dx, dy]);
-      }
-    }
-  }
-
   // --- Update stroke and fill ---
   if (graphic.mark) {
     const strokeChanged = applyDynamicStrokeStyling(
@@ -200,6 +184,22 @@ function getPointStyle(symbolizer, feature, getProperty) {
         olImage.getFill()
       );
       olStyle.setImage(olImage);
+    }
+  }
+
+  // Update displacement
+  const { displacement } = graphic;
+  if (displacement) {
+    const { displacementx, displacementy } = displacement;
+    if (
+      typeof displacementx !== 'undefined' ||
+      typeof displacementy !== 'undefined'
+    ) {
+      const dx = evaluate(displacementx, feature, getProperty) || 0.0;
+      const dy = evaluate(displacementy, feature, getProperty) || 0.0;
+      if (dx !== 0.0 || dy !== 0.0) {
+        olImage.setDisplacement([dx, dy]);
+      }
     }
   }
 

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -1042,6 +1042,10 @@ describe('Styling with dynamic SVG Parameters', () => {
       myStrokeOpacity: 1.0,
       myFillColor: '#646464', // [100, 100, 100]
       myFillOpacity: 0.4,
+      mySize: 14,
+      myAngle: 42,
+      myDisplacementX: 15,
+      myDisplacementY: 45,
     },
   };
 
@@ -1243,6 +1247,14 @@ describe('Styling with dynamic SVG Parameters', () => {
       expect(olStyle.getImage().getFill().getColor()).to.equal(
         'rgba(100, 100, 100, 0.4)'
       );
+    });
+
+    it('Dynamic rotation', () => {
+      expect(olStyle.getImage().getRotation()).to.equal(42);
+    });
+
+    it('Dynamic displacement', () => {
+      expect(olStyle.getImage().getDisplacement()).to.deep.equal([15, 45]);
     });
   });
 

--- a/test/OlStyler.test.js
+++ b/test/OlStyler.test.js
@@ -1250,7 +1250,9 @@ describe('Styling with dynamic SVG Parameters', () => {
     });
 
     it('Dynamic rotation', () => {
-      expect(olStyle.getImage().getRotation()).to.equal(42);
+      const imageRotation = olStyle.getImage().getRotation();
+      const imageRotationDegrees = (180.0 * imageRotation) / Math.PI;
+      expect(imageRotationDegrees).to.equal(42);
     });
 
     it('Dynamic displacement', () => {

--- a/test/data/dynamic-point-symbolizer.sld.js
+++ b/test/data/dynamic-point-symbolizer.sld.js
@@ -36,7 +36,7 @@ export const dynamicPointSymbolizerSld = `<?xml version="1.0" encoding="UTF-8"?>
                 <ogc:PropertyName>mySize</ogc:PropertyName>
               </se:Size>
               <se:Rotation>
-                <ogc:PropertyName>myRotation</ogc:PropertyName>
+                <ogc:PropertyName>myAngle</ogc:PropertyName>
               </se:Rotation>
               <se:Displacement>
                 <se:DisplacementX>

--- a/test/data/dynamic-point-symbolizer.sld.js
+++ b/test/data/dynamic-point-symbolizer.sld.js
@@ -9,31 +9,44 @@ export const dynamicPointSymbolizerSld = `<?xml version="1.0" encoding="UTF-8"?>
       <se:FeatureTypeStyle>
         <se:Rule>
           <se:PointSymbolizer>
-          <se:Graphic>
-            <se:Mark>
-              <se:WellKnownName>square</se:WellKnownName>
-              <se:Fill>
-                <se:SvgParameter name="fill">
-                  <ogc:PropertyName>myFillColor</ogc:PropertyName>
-                </se:SvgParameter>
-                <se:SvgParameter name="fill-opacity">
-                  <ogc:PropertyName>myFillOpacity</ogc:PropertyName>
-                </se:SvgParameter>
-              </se:Fill>
-              <se:Stroke>
-                <se:SvgParameter name="stroke">
-                  <ogc:PropertyName>myStrokeColor</ogc:PropertyName>
-                </se:SvgParameter>
-                <se:SvgParameter name="stroke-opacity">
-                  <ogc:PropertyName>myStrokeOpacity</ogc:PropertyName>
-                </se:SvgParameter>
-                <se:SvgParameter name="stroke-width">
-                  <ogc:PropertyName>myStrokeWidth</ogc:PropertyName>
-                </se:SvgParameter>
-              </se:Stroke>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>square</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">
+                    <ogc:PropertyName>myFillColor</ogc:PropertyName>
+                  </se:SvgParameter>
+                  <se:SvgParameter name="fill-opacity">
+                    <ogc:PropertyName>myFillOpacity</ogc:PropertyName>
+                  </se:SvgParameter>
+                </se:Fill>
+                <se:Stroke>
+                  <se:SvgParameter name="stroke">
+                    <ogc:PropertyName>myStrokeColor</ogc:PropertyName>
+                  </se:SvgParameter>
+                  <se:SvgParameter name="stroke-opacity">
+                    <ogc:PropertyName>myStrokeOpacity</ogc:PropertyName>
+                  </se:SvgParameter>
+                  <se:SvgParameter name="stroke-width">
+                    <ogc:PropertyName>myStrokeWidth</ogc:PropertyName>
+                  </se:SvgParameter>
+                </se:Stroke>
               </se:Mark>
-            <se:Size>10</se:Size>
-          </se:Graphic>
+              <se:Size>
+                <ogc:PropertyName>mySize</ogc:PropertyName>
+              </se:Size>
+              <se:Rotation>
+                <ogc:PropertyName>myRotation</ogc:PropertyName>
+              </se:Rotation>
+              <se:Displacement>
+                <se:DisplacementX>
+                  <ogc:PropertyName>myDisplacementX</ogc:PropertyName>
+                </se:DisplacementX>
+                <se:DisplacementY>
+                  <ogc:PropertyName>myDisplacementY</ogc:PropertyName>
+                </se:DisplacementY>
+              </se:Displacement>
+            </se:Graphic>
           </se:PointSymbolizer>
         </se:Rule>
       </se:FeatureTypeStyle>


### PR DESCRIPTION
This PR fixes an issue where (dynamic) rotation and displacement properties were not set on graphic Marks if one or more SvgParameters also have dynamic values.