### PR TITLE
Fix midpoint calculation

### DIFF
--- a/src/styles/geometryCalcs.js
+++ b/src/styles/geometryCalcs.js
@@ -33,7 +33,13 @@ function calculateAngle(p1, p2, invertY) {
 }
 
 // eslint-disable-next-line import/prefer-default-export
-export function splitLineString(geometry, graphicSpacing, options = {}) {
+export function splitLineString(geometry, graphicSpacing, _options = {}) {
+  const defaultOptions = {
+    minimumGraphicSpacing: 0,
+  };
+
+  const splitOptions = Object.assign(defaultOptions, _options);
+
   const coords = geometry.getCoordinates();
 
   // Handle degenerate cases.
@@ -48,25 +54,25 @@ export function splitLineString(geometry, graphicSpacing, options = {}) {
   }
 
   // Handle first point placement case.
-  if (options.placement === PLACEMENT_FIRSTPOINT) {
+  if (splitOptions.placement === PLACEMENT_FIRSTPOINT) {
     const p1 = coords[0];
     const p2 = coords[1];
-    return [[p1[0], p1[1], calculateAngle(p1, p2, options.invertY)]];
+    return [[p1[0], p1[1], calculateAngle(p1, p2, splitOptions.invertY)]];
   }
 
   // Handle last point placement case.
-  if (options.placement === PLACEMENT_LASTPOINT) {
+  if (splitOptions.placement === PLACEMENT_LASTPOINT) {
     const p1 = coords[coords.length - 2];
     const p2 = coords[coords.length - 1];
-    return [[p2[0], p2[1], calculateAngle(p1, p2, options.invertY)]];
+    return [[p2[0], p2[1], calculateAngle(p1, p2, splitOptions.invertY)]];
   }
 
   const totalLength = geometry.getLength();
-  const gapSize = Math.max(graphicSpacing, 0.1); // 0.1 px minimum gap size to prevent accidents.
+  const gapSize = Math.max(graphicSpacing, splitOptions.minimumGraphicSpacing);
 
   // Measure along line to place the next point.
   // Can start at a nonzero value if initialGap is used.
-  let nextPointMeasure = options.initialGap || 0.0;
+  let nextPointMeasure = splitOptions.initialGap || 0.0;
   let pointIndex = 0;
   const currentSegmentStart = [...coords[0]];
   const currentSegmentEnd = [...coords[1]];
@@ -106,11 +112,11 @@ export function splitLineString(geometry, graphicSpacing, options = {}) {
       const angle = calculateAngle(
         currentSegmentStart,
         currentSegmentEnd,
-        options.invertY
+        splitOptions.invertY
       );
       if (
-        !options.extent ||
-        containsCoordinate(options.extent, splitPointCoords)
+        !splitOptions.extent ||
+        containsCoordinate(splitOptions.extent, splitPointCoords)
       ) {
         splitPointCoords.push(angle);
         splitPoints.push(splitPointCoords);

--- a/src/styles/geometryCalcs.js
+++ b/src/styles/geometryCalcs.js
@@ -121,3 +121,18 @@ export function splitLineString(geometry, graphicSpacing, options = {}) {
 
   return splitPoints;
 }
+
+/**
+ * @private
+ * Get the point located at the middle along a line string.
+ * @param {ol/geom/LineString} geometry An OpenLayers LineString geometry.
+ * @returns {Array<number>} An [x, y] coordinate array.
+ */
+export function getLineMidpoint(geometry) {
+  // Use the splitpoints routine to distribute points over the line with
+  // a point-to-point distance along the line equal to half line length.
+  // This results in three points. Take the middle point.
+  const splitPoints = splitLineString(geometry, geometry.getLength() / 2);
+  const [x, y] = splitPoints[1];
+  return [x, y];
+}

--- a/src/styles/graphicStrokeStyle.js
+++ b/src/styles/graphicStrokeStyle.js
@@ -100,6 +100,8 @@ function renderStrokeMarks(
       extent: render.extent_,
       placement: options.placement,
       initialGap: options.initialGap,
+      // Use graphic spacing of at least 0.1 px to prevent an infinite number of split points happening by accident.
+      minimumGraphicSpacing: 0.1,
     }
   );
 

--- a/src/styles/linePointStyle.js
+++ b/src/styles/linePointStyle.js
@@ -1,22 +1,7 @@
 import { MultiPoint, Point } from 'ol/geom';
 
 import getPointStyle from './pointStyle';
-import { splitLineString } from './geometryCalcs';
-
-/**
- * @private
- * Get the point located at the middle along a line string.
- * @param {ol/geom/LineString} geometry An OpenLayers LineString geometry.
- * @returns {Array<number>} An [x, y] coordinate array.
- */
-function getLineMidpoint(geometry) {
-  // Use the splitpoints routine to distribute points over the line with
-  // a point-to-point distance along the line equal to half line length.
-  // This results in three points. Take the middle point.
-  const splitPoints = splitLineString(geometry, geometry.getLength() / 2);
-  const [x, y] = splitPoints[1];
-  return [x, y];
-}
+import { getLineMidpoint } from './geometryCalcs';
 
 /**
  * @private

--- a/test/geometryCalcs.test.js
+++ b/test/geometryCalcs.test.js
@@ -50,4 +50,25 @@ describe('Geometry calcs', () => {
     const midpoint = getLineMidpoint(geometry);
     expect(midpoint).to.deep.equal([3, -2]);
   });
+
+  it('Midpoint calculation should not crash on small (length < 0.1 map units) geometries', () => {
+    const shortLineGeoJSON = {
+      type: 'Feature',
+      id: 'some.feature.1',
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [106652.4318, 485565.3644],
+          [106652.4268, 485565.414],
+        ],
+      },
+      geometry_name: 'geom',
+      properties: {},
+    };
+
+    const feature = fmtGeoJSON.readFeature(shortLineGeoJSON);
+    const geometry = feature.getGeometry();
+    const midpoint = getLineMidpoint(geometry);
+    expect(midpoint).to.deep.equal([106652.4293, 485565.3892]);
+  });
 });

--- a/test/geometryCalcs.test.js
+++ b/test/geometryCalcs.test.js
@@ -1,6 +1,6 @@
 /* global describe it expect beforeEach */
 import OLFormatGeoJSON from 'ol/format/GeoJSON';
-import { splitLineString } from '../src/styles/geometryCalcs';
+import { getLineMidpoint, splitLineString } from '../src/styles/geometryCalcs';
 
 describe('Geometry calcs', () => {
   const lineGeoJSON = {
@@ -42,5 +42,12 @@ describe('Geometry calcs', () => {
       [3, -2],
       [4, 1],
     ]);
+  });
+
+  it('Midpoint calculation by splitting on half geometry length', () => {
+    const feature = fmtGeoJSON.readFeature(lineGeoJSON);
+    const geometry = feature.getGeometry();
+    const midpoint = getLineMidpoint(geometry);
+    expect(midpoint).to.deep.equal([3, -2]);
   });
 });


### PR DESCRIPTION
This PR fixes a crash that occurs when using a point symbolizer for linestrings shorter than 0.1 map units.