### PR TITLE
Ignore comments

### DIFF
--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -510,8 +510,8 @@
         childExpression.type = 'literal';
         childExpression.typeHint = parseOptions.typeHint;
         childExpression.value = childNode.textContent;
-      } else {
-        // Add ogc:Literal elements and plain text nodes as type:literal.
+      } else if (childNode.nodeType !== Node.COMMENT_NODE) {
+        // Add ogc:Literal elements and plain non-comment text nodes as type:literal.
         childExpression.type = 'literal';
         childExpression.typeHint = parseOptions.typeHint;
         childExpression.value = childNode.textContent.trim();
@@ -717,10 +717,16 @@
     var parser = new DOMParser();
     var doc = parser.parseFromString(sld, 'application/xml');
 
-    for (var n = doc.firstChild; n; n = n.nextSibling) {
-      result.version = n.getAttribute('version');
-      readNode(n, result);
+    var rootNode = doc.documentElement;
+    if (rootNode.localName !== 'StyledLayerDescriptor') {
+      throw new Error(
+        ("Expected StyledLayerDescriptor root element. Found " + (rootNode.localName) + " instead.")
+      );
     }
+
+    result.version = rootNode.getAttribute('version');
+    readNode(rootNode, result);
+
     return result;
   }
 

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -438,10 +438,16 @@ export default function Reader(sld) {
   const parser = new DOMParser();
   const doc = parser.parseFromString(sld, 'application/xml');
 
-  for (let n = doc.firstChild; n; n = n.nextSibling) {
-    result.version = n.getAttribute('version');
-    readNode(n, result);
+  const rootNode = doc.documentElement;
+  if (rootNode.localName !== 'StyledLayerDescriptor') {
+    throw new Error(
+      `Expected StyledLayerDescriptor root element. Found ${rootNode.localName} instead.`
+    );
   }
+
+  result.version = rootNode.getAttribute('version');
+  readNode(rootNode, result);
+
   return result;
 }
 

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -227,8 +227,8 @@ function addParameterValueProp(node, obj, prop, options = {}) {
       childExpression.type = 'literal';
       childExpression.typeHint = parseOptions.typeHint;
       childExpression.value = childNode.textContent;
-    } else {
-      // Add ogc:Literal elements and plain text nodes as type:literal.
+    } else if (childNode.nodeType !== Node.COMMENT_NODE) {
+      // Add ogc:Literal elements and plain non-comment text nodes as type:literal.
       childExpression.type = 'literal';
       childExpression.typeHint = parseOptions.typeHint;
       childExpression.value = childNode.textContent.trim();

--- a/test/Filter.test.js
+++ b/test/Filter.test.js
@@ -193,7 +193,7 @@ describe('filter rules', () => {
         const filterXml = `<StyledLayerDescriptor xmlns="http://www.opengis.net/ogc"><Filter>
           <PropertyIsLike wildCard="%" singleChar="?" escapeChar="\\">
             <PropertyName>value</PropertyName>
-            <Literal></Literal> <!-- will be overidden in testLike function below -->
+            <Literal>[content overwritten by testLike function below]</Literal>
           </PropertyIsLike>
         </Filter></StyledLayerDescriptor>`;
         filterBase = Reader(filterXml).filter;

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -5,6 +5,7 @@ import { sld11 } from './data/test11.sld';
 import { dynamicSld } from './data/dynamic.sld';
 import { graphicstrokeSymbolizerSld } from './data/graphicstrokeSymbolizer.sld';
 import { graphicStrokeWithGap } from './data/graphicstroke-with-gap.sld';
+import { graphicStrokeWithComments } from './data/graphicstroke-with-comments.sld';
 import { multipleSymbolizersSld } from './data/multiple-symbolizers.sld';
 import { staticPolygonSymbolizerSld } from './data/static-polygon-symbolizer.sld';
 import { dynamicPolygonSymbolizerSld } from './data/dynamic-polygon-symbolizer.sld';
@@ -193,6 +194,24 @@ describe('Reads xml sld 11', () => {
     const [symbolizer] = rule.textsymbolizer;
     expect(symbolizer).to.be.an.instanceof(Object);
     expect(symbolizer.fill).to.be.an.instanceof(Object);
+  });
+});
+
+describe('Other reader tests', () => {
+  it('Reader ignores comments', () => {
+    const resultWithComments = Reader(graphicStrokeWithComments);
+    expect(resultWithComments).to.be.ok;
+  });
+
+  it('Reader throws when root node is not a StyledLayerDescriptor', () => {
+    expect(() => Reader('<PointSymbolizer />')).to.throw(
+      'Expected StyledLayerDescriptor root element. Found PointSymbolizer instead.'
+    );
+  });
+
+  it('Reader does not throw when root node is a namespaced StyledLayerDescriptor', () => {
+    const result2 = Reader('<sld:StyledLayerDescriptor xmlns:sld="http://www.opengis.net/sld" />');
+    expect(result2).to.be.ok;
   });
 });
 

--- a/test/data/graphicstroke-with-comments.sld.js
+++ b/test/data/graphicstroke-with-comments.sld.js
@@ -1,0 +1,45 @@
+export const graphicStrokeWithComments = `<?xml version="1.0" encoding="UTF-8"?>
+<!--hello--><StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd"
+  xmlns:se="http://www.opengis.net/se" version="1.1.0"
+  xmlns:ogc="http://www.opengis.net/ogc">
+  <!--hello--><NamedLayer>
+    <!--hello--><se:Name>test_layer</se:Name>
+    <!--hello--><UserStyle>
+      <!--hello--><se:Name>test_style</se:Name>
+      <!--hello--><se:FeatureTypeStyle>
+        <!--hello--><se:Rule>
+          <!--hello--><se:Name>Single symbol</se:Name>
+          <!--hello--><se:LineSymbolizer>
+            <!--hello--><se:Stroke>
+              <!--hello--><se:GraphicStroke>
+                <!--hello--><se:Graphic>
+                  <!--hello--><se:Mark>
+                    <!--hello--><se:WellKnownName>circle</se:WellKnownName>
+                    <!--hello--><se:Fill>
+                      <!--hello--><se:SvgParameter name="fill">#ff8000</se:SvgParameter>
+                    </se:Fill>
+                    <!--hello--><se:Stroke>
+                      <!--hello--><se:SvgParameter name="stroke">#232323</se:SvgParameter>
+                      <!--hello--><se:SvgParameter name="stroke-width">0.5</se:SvgParameter>
+                    </se:Stroke>
+                  </se:Mark>
+                  <!--hello--><se:Size>6</se:Size>
+                </se:Graphic>
+                <!--hello--><se:Gap>
+                  <!--hello--><ogc:Literal>14</ogc:Literal>
+                </se:Gap>
+                <!--hello--><se:InitialGap>
+                  <!--hello--><ogc:Literal>6</ogc:Literal>
+                </se:InitialGap>
+              </se:GraphicStroke>
+            </se:Stroke>
+          </se:LineSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>`;
+
+export default graphicStrokeWithComments;

--- a/test/data/textSymbolizer-cdata.sld.js
+++ b/test/data/textSymbolizer-cdata.sld.js
@@ -11,7 +11,7 @@ export const textSymbolizerCDataSld = `<?xml version="1.0" encoding="UTF-8"?>
       <FeatureTypeStyle>
         <Rule>
           <TextSymbolizer>
-            <Label>Size:<![CDATA[ ]]><ogc:PropertyName>size</ogc:PropertyName><![CDATA[
+            <Label><!--IGNORE THIS COMMENT!-->Size:<![CDATA[ ]]><ogc:PropertyName>size</ogc:PropertyName><![CDATA[
 ]]>Angle:<![CDATA[ ]]><ogc:PropertyName>angle</ogc:PropertyName>
             </Label>
           </TextSymbolizer>


### PR DESCRIPTION
This PR fixes handling of comments in SLD xml:
* Reader does not throw if there's a comment before the root element.
* Reader ignores comment nodes inside SLD elements that hold a (text) value.

Additionally: Reader will now throw if the root node of the SLD xml is not a `StyledLayerDescriptor`.
