### PR TITLE
Parse SLD 1.1 Description elements

### DIFF
--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -687,6 +687,7 @@
     Name: addPropWithTextContent,
     Title: addPropWithTextContent,
     Abstract: addPropWithTextContent,
+    Description: readNode,
     MaxScaleDenominator: addNumericProp,
     MinScaleDenominator: addNumericProp},
     FilterParsers,

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -407,6 +407,7 @@ const parsers = {
   Name: addPropWithTextContent,
   Title: addPropWithTextContent,
   Abstract: addPropWithTextContent,
+  Description: readNode,
   MaxScaleDenominator: addNumericProp,
   MinScaleDenominator: addNumericProp,
   ...FilterParsers,

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -195,6 +195,24 @@ describe('Reads xml sld 11', () => {
     expect(symbolizer).to.be.an.instanceof(Object);
     expect(symbolizer.fill).to.be.an.instanceof(Object);
   });
+  describe('Metadata', () => {
+    let rule;
+    beforeEach(() => {
+      rule = result.layers[0].styles[0].featuretypestyles[0].rules[0];
+    });
+
+    it('Rule name', () => {
+      expect(rule.name).to.equal('Other');
+    });
+
+    it('Takes Rule title from description', () => {
+      expect(rule.title).to.equal('Other provinces');
+    });
+
+    it('Takes Rule abstract from description', () => {
+      expect(rule.abstract).to.equal('This rule matches all other provinces');
+    });
+  });
 });
 
 describe('Other reader tests', () => {

--- a/test/data/test11.sld.js
+++ b/test/data/test11.sld.js
@@ -8,7 +8,8 @@ export const sld11 = `<?xml version="1.0" encoding="UTF-8"?>
         <se:Rule>
           <se:Name>Other</se:Name>
           <se:Description>
-            <se:Title>Other</se:Title>
+            <se:Title>Other provinces</se:Title>
+            <se:Abstract>This rule matches all other provinces</se:Abstract>
           </se:Description>
           <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
             <ogc:PropertyIsNotEqualTo>


### PR DESCRIPTION
Parse Title and Abstract from SLD v1.1.0 Description elements and add them as properties to the parent element.

Example:
```xml
<se:Rule>
  <se:Name>Other</se:Name>
  <se:Description>
    <se:Title>Other provinces</se:Title>
    <se:Abstract>This rule matches all other provinces</se:Abstract>
  </se:Description>
  ...
</se:Rule>
```

Results in 
```
rule.name     --> "Other"
rule.title    --> "Other provinces"
rule.abstract --> "This rule matches all other provinces"
```
