### PR TITLE
Parse uom

### DIFF
--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -343,7 +343,7 @@
   function addSymbolizer(node, obj, prop) {
     var property = prop.toLowerCase();
     obj[property] = obj[property] || [];
-    var item = {};
+    var item = { type: 'symbolizer' };
 
     // Check and add if symbolizer node has uom attribute.
     // If there is no uom attribute, default to pixel.
@@ -4011,17 +4011,6 @@
 
     // Keep track of whether a callback has been registered per image url.
     var callbackRef = {};
-
-    //Todo: introduce context object outside returned function.
-    //Set context.getProperty outside returned function.
-    //Set context.convertMapResolution function outside returned function.
-    //Set context.resolution inside returned function at each invocation through context.convertMapResolution.
-    //(Note: setting context.resolution is a convenience, so it's not necessary to pass both context and mapResolution to the style functions).
-    //Pass context to OlStyler and then to getBla style functions instead of getProperty.
-    //Now all getBla functions returning a style can access the real resolution for non-pixel uoms.
-    //The graphicStroke render function can also get hold of the real resolution by:
-    //* Reading map resolution from renderContext.resolution.
-    //* Converting it into a real resolution via context.convertMapResolution.
 
     return function (feature, mapResolution) {
       // Determine resolution in meters/pixel.

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -4,6 +4,28 @@
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.SLDReader = {}, global.ol.style, global.ol.render, global.ol.geom, global.ol.extent, global.ol.has));
 })(this, (function (exports, style, render, geom, extent, has) { 'use strict';
 
+  var IMAGE_LOADING = 'IMAGE_LOADING';
+  var IMAGE_LOADED = 'IMAGE_LOADED';
+  var IMAGE_ERROR = 'IMAGE_ERROR';
+
+  // SLD Spec: Default size for Marks without Size should be 6 pixels.
+  var DEFAULT_MARK_SIZE = 6; // pixels
+  // SLD Spec: Default size for ExternalGraphic with an unknown native size,
+  // like SVG without dimensions, should be 16 pixels.
+  var DEFAULT_EXTERNALGRAPHIC_SIZE = 16; // pixels
+
+  // QGIS Graphic stroke placement options
+  var PLACEMENT_DEFAULT = 'PLACEMENT_DEFAULT';
+  var PLACEMENT_FIRSTPOINT = 'PLACEMENT_FIRSTPOINT';
+  var PLACEMENT_LASTPOINT = 'PLACEMENT_LASTPOINT';
+
+  // Supported units of measure
+  var UOM_METRE = 'metre';
+  var UOM_FOOT = 'foot';
+  var UOM_PIXEL = 'pixel';
+  // None = number is dimensionless.
+  var UOM_NONE = 'none';
+
   /**
    * Factory methods for filterelements
    * @see http://schemas.opengis.net/filter/1.0.0/filter.xsd
@@ -293,6 +315,8 @@
     'fillOpacity',
     'fontSize' ]);
 
+  var dimensionlessSvgProps = new Set(['strokeOpacity', 'fillOpacity']);
+
   /**
    * Generic parser for elements with maxOccurs > 1
    * it pushes result of readNode(node) to array on obj[prop]
@@ -300,12 +324,59 @@
    * @param {Element} node the xml element to parse
    * @param {object} obj  the object to modify
    * @param {string} prop key on obj to hold array
+   * @param {object} options Parse options.
    */
-  function addPropArray(node, obj, prop) {
+  function addPropArray(node, obj, prop, options) {
     var property = prop.toLowerCase();
     obj[property] = obj[property] || [];
     var item = {};
-    readNode(node, item);
+    readNode(node, item, options);
+    obj[property].push(item);
+  }
+
+  /**
+   * Parse symbolizer element and extract units of measure attribute.
+   * @param {Element} node the xml element to parse
+   * @param {object} obj  the object to modify
+   * @param {string} prop key on obj to hold array
+   */
+  function addSymbolizer(node, obj, prop) {
+    var property = prop.toLowerCase();
+    obj[property] = obj[property] || [];
+    var item = {};
+
+    // Check and add if symbolizer node has uom attribute.
+    // If there is no uom attribute, default to pixel.
+    var uom = node.getAttribute('uom');
+    if (uom) {
+      switch (uom) {
+        // From symbology encoding spec:
+        // The following uom definitions are recommended to be used:
+        case 'http://www.opengeospatial.org/se/units/metre':
+          item.uom = UOM_METRE;
+          break;
+        case 'http://www.opengeospatial.org/se/units/foot':
+          item.uom = UOM_FOOT;
+          break;
+        case 'http://www.opengeospatial.org/se/units/pixel':
+          item.uom = UOM_PIXEL;
+          break;
+        default:
+          // eslint-disable-next-line no-console
+          console.warn(
+            'Unsupported uom attribute found, one of http://www.opengeospatial.org/se/units/(metre|feet|pixel) expected.'
+          );
+          item.uom = UOM_PIXEL;
+          break;
+      }
+    } else {
+      item.uom = UOM_PIXEL;
+    }
+
+    readNode(node, item, {
+      // Note: text symbolizer units of measure are always pixel.
+      uom: property === 'textsymbolizer' ? UOM_PIXEL : item.uom,
+    });
     obj[property].push(item);
   }
 
@@ -316,11 +387,12 @@
    * @param {Element} node the xml element to parse
    * @param {object} obj  the object to modify
    * @param {string} prop key on obj to hold empty object
+   * @param {object} options Parse options.
    */
-  function addProp(node, obj, prop) {
+  function addProp(node, obj, prop, options) {
     var property = prop.toLowerCase();
     obj[property] = {};
-    readNode(node, obj[property]);
+    readNode(node, obj[property], options);
   }
 
   /**
@@ -329,13 +401,12 @@
    * @param {Element} node [description]
    * @param {object} obj  [description]
    * @param {string} prop [description]
-   * @param {bool} [trimText] Trim whitespace from text content (default false).
+   * @param {object} options Parse options.
+   * @param {bool} [options.trimText] Trim whitespace from text content (default false).
    */
-  function addPropWithTextContent(node, obj, prop, trimText) {
-    if ( trimText === void 0 ) trimText = false;
-
+  function addPropWithTextContent(node, obj, prop, options) {
     var property = prop.toLowerCase();
-    if (trimText) {
+    if (options && options.trimText) {
       obj[property] = node.textContent.trim();
     } else {
       obj[property] = node.textContent;
@@ -345,6 +416,7 @@
   /**
    * Assigns numeric value of text content to obj.prop.
    * Assigns NaN if the text value is not a valid text representation of a floating point number.
+   * If you need a value with unit of measure, use addParameterValueProp instead.
    * @private
    * @param {Element} node The XML node element.
    * @param {object} obj  The object to add the element value to.
@@ -365,17 +437,26 @@
    * @param {string} typeHint Expression type. Choose 'string' or 'number'.
    * @param {boolean} concatenateLiterals When true, and when all expressions are literals,
    * concatenate all literal expressions into a single string.
+   * @param {string} uom Unit of measure.
    * @return {Array<OGCExpression>|OGCExpression|string} Simplified version of the expression array.
    */
-  function simplifyChildExpressions(expressions, typeHint, concatenateLiterals) {
+  function simplifyChildExpressions(
+    expressions,
+    typeHint,
+    concatenateLiterals,
+    uom
+  ) {
     if (!Array.isArray(expressions)) {
       return expressions;
     }
 
-    // Replace each literal expression with its value.
+    // Replace each literal expression with its value, unless it has units of measure that are not pixels.
     var simplifiedExpressions = expressions
       .map(function (expression) {
-        if (expression.type === 'literal') {
+        if (
+          expression.type === 'literal' &&
+          !(expression.uom === UOM_METRE || expression.uom === UOM_FOOT)
+        ) {
           return expression.value;
         }
         return expression;
@@ -400,6 +481,7 @@
     return {
       type: 'expression',
       typeHint: typeHint,
+      uom: uom,
       children: simplifiedExpressions,
     };
   }
@@ -425,10 +507,11 @@
    * @param {object} obj Object to add XML node contents to.
    * @param {string} prop Property name on obj that will hold the parsed node contents.
    * @param {object} [options] Parse options.
-   * @param {object} [options.skipEmptyNodes] Default true. If true, emtpy (whitespace-only) text nodes will me omitted in the result.
-   * @param {object} [options.forceLowerCase] Default true. If true, convert prop name to lower case before adding it to obj.
-   * @param {object} [options.typeHint] Default 'string'. When set to 'number', a simple literal value will be converted to a number.
-   * @param {object} [options.concatenateLiterals] Default true. When true, and when all expressions are literals,
+   * @param {bool} [options.skipEmptyNodes] Default true. If true, emtpy (whitespace-only) text nodes will me omitted in the result.
+   * @param {bool} [options.forceLowerCase] Default true. If true, convert prop name to lower case before adding it to obj.
+   * @param {string} [options.typeHint] Default 'string'. When set to 'number', a simple literal value will be converted to a number.
+   * @param {bool} [options.concatenateLiterals] Default true. When true, and when all expressions are literals,
+   * @param {string} [options.uom] Unit of measure.
    * concatenate all literal expressions into a single string.
    */
   function addParameterValueProp(node, obj, prop, options) {
@@ -439,6 +522,7 @@
       forceLowerCase: true,
       typeHint: 'string',
       concatenateLiterals: true,
+      uom: UOM_NONE,
     };
 
     var parseOptions = Object.assign({}, defaultParseOptions,
@@ -470,9 +554,8 @@
         // Parse function parameters.
         // Parse child expressions, and add them to the comparison object.
         var parsed = {};
-        addParameterValueProp(childNode, parsed, 'params', {
-          concatenateLiterals: false,
-        });
+        addParameterValueProp(childNode, parsed, 'params', Object.assign({}, parseOptions,
+          {concatenateLiterals: false}));
         if (Array.isArray(parsed.params.children)) {
           // Case 0 or more than 1 children.
           childExpression.params = parsed.params.children;
@@ -494,9 +577,8 @@
         // Parse function parameters.
         // Parse child expressions, and add them to the comparison object.
         var parsed$1 = {};
-        addParameterValueProp(childNode, parsed$1, 'params', {
-          concatenateLiterals: false,
-        });
+        addParameterValueProp(childNode, parsed$1, 'params', Object.assign({}, parseOptions,
+          {concatenateLiterals: false}));
         if (Array.isArray(parsed$1.params.children)) {
           // Case 0 or more than 1 children.
           childExpression.params = parsed$1.params.children;
@@ -533,15 +615,29 @@
     var simplifiedValue = simplifyChildExpressions(
       childExpressions,
       parseOptions.typeHint,
-      parseOptions.concatenateLiterals
+      parseOptions.concatenateLiterals,
+      parseOptions.uom
     );
 
     // Convert simple string value to number if type hint is number.
+    // Keep full literal expression if unit of measure is in metre or foot.
     if (
       typeof simplifiedValue === 'string' &&
       parseOptions.typeHint === 'number'
     ) {
-      simplifiedValue = parseFloat(simplifiedValue);
+      // If numbers are written with 'px' at the end, they override the symbolizer's own uom.
+      var uom =
+        simplifiedValue.indexOf('px') > -1 ? UOM_PIXEL : parseOptions.uom;
+      if (uom === UOM_METRE || uom === UOM_FOOT) {
+        simplifiedValue = {
+          type: 'literal',
+          typeHint: 'number',
+          value: parseFloat(simplifiedValue),
+          uom: uom,
+        };
+      } else {
+        simplifiedValue = parseFloat(simplifiedValue);
+      }
     }
 
     obj[propertyName] = simplifiedValue;
@@ -551,6 +647,19 @@
     if ( options === void 0 ) options = {};
 
     addParameterValueProp(node, obj, prop, Object.assign({}, options, {typeHint: 'number'}));
+  }
+
+  function addDimensionlessNumericParameterValueProp(
+    node,
+    obj,
+    prop,
+    options
+  ) {
+    if ( options === void 0 ) options = {};
+
+    addParameterValueProp(node, obj, prop, Object.assign({}, options,
+      {typeHint: 'number',
+      uom: UOM_NONE}));
   }
 
   /**
@@ -578,8 +687,11 @@
    * @param  {object} obj
    * @param  {string} prop
    * @param  {string} parameterGroup Name of parameter group.
+   * @param  {object} options Parse options.
    */
-  function addParameterValue(element, obj, prop, parameterGroup) {
+  function addParameterValue(element, obj, prop, parameterGroup, options) {
+    var parseOptions = Object.assign({}, options);
+
     obj[parameterGroup] = obj[parameterGroup] || {};
     var name = element
       .getAttribute('name')
@@ -587,18 +699,23 @@
       .replace(/-(.)/g, function (match, group1) { return group1.toUpperCase(); });
 
     // Flag certain SVG parameters as numeric.
+    // Some SVG parameters are always dimensionless (like opacity).
     var typeHint = 'string';
+    var uom = parseOptions.uom;
     if (parameterGroup === 'styling') {
       if (numericSvgProps.has(name)) {
         typeHint = 'number';
       }
+      if (dimensionlessSvgProps.has(name)) {
+        uom = UOM_NONE;
+      }
     }
 
-    addParameterValueProp(element, obj[parameterGroup], name, {
-      skipEmptyNodes: true,
+    addParameterValueProp(element, obj[parameterGroup], name, Object.assign({}, options,
+      {skipEmptyNodes: true,
       forceLowerCase: false,
       typeHint: typeHint,
-    });
+      uom: uom}));
   }
 
   var FilterParsers = {
@@ -611,20 +728,21 @@
   };
 
   var SymbParsers = {
-    PolygonSymbolizer: addPropArray,
-    LineSymbolizer: addPropArray,
-    PointSymbolizer: addPropArray,
-    TextSymbolizer: addPropArray,
+    PolygonSymbolizer: addSymbolizer,
+    LineSymbolizer: addSymbolizer,
+    PointSymbolizer: addSymbolizer,
+    TextSymbolizer: addSymbolizer,
     Fill: addProp,
     Stroke: addProp,
     GraphicStroke: addProp,
-    GraphicFill: addProp,
+    GraphicFill: function (node, obj, prop, options) { return addProp(node, obj, prop, Object.assign({}, options, {uom: UOM_PIXEL})); },
     Graphic: addProp,
     ExternalGraphic: addProp,
     Gap: addNumericParameterValueProp,
     InitialGap: addNumericParameterValueProp,
     Mark: addProp,
-    Label: function (node, obj, prop) { return addParameterValueProp(node, obj, prop, { skipEmptyNodes: false }); },
+    Label: function (node, obj, prop, options) { return addParameterValueProp(node, obj, prop, Object.assign({}, options,
+        {skipEmptyNodes: false})); },
     Halo: addProp,
     Font: addProp,
     Radius: addNumericParameterValueProp,
@@ -633,22 +751,22 @@
     LinePlacement: addProp,
     PerpendicularOffset: addNumericParameterValueProp,
     AnchorPoint: addProp,
-    AnchorPointX: addNumericParameterValueProp,
-    AnchorPointY: addNumericParameterValueProp,
-    Opacity: addNumericParameterValueProp,
-    Rotation: addNumericParameterValueProp,
+    AnchorPointX: addDimensionlessNumericParameterValueProp,
+    AnchorPointY: addDimensionlessNumericParameterValueProp,
+    Opacity: addDimensionlessNumericParameterValueProp,
+    Rotation: addDimensionlessNumericParameterValueProp,
     Displacement: addProp,
     DisplacementX: addNumericParameterValueProp,
     DisplacementY: addNumericParameterValueProp,
     Size: addNumericParameterValueProp,
     WellKnownName: addPropWithTextContent,
     MarkIndex: addNumericProp,
-    VendorOption: function (element, obj, prop) { return addParameterValue(element, obj, prop, 'vendoroptions'); },
+    VendorOption: function (element, obj, prop, options) { return addParameterValue(element, obj, prop, 'vendoroptions', options); },
     OnlineResource: function (element, obj) {
       obj.onlineresource = element.getAttribute('xlink:href');
     },
-    CssParameter: function (element, obj, prop) { return addParameterValue(element, obj, prop, 'styling'); },
-    SvgParameter: function (element, obj, prop) { return addParameterValue(element, obj, prop, 'styling'); },
+    CssParameter: function (element, obj, prop, options) { return addParameterValue(element, obj, prop, 'styling', options); },
+    SvgParameter: function (element, obj, prop, options) { return addParameterValue(element, obj, prop, 'styling', options); },
   };
 
   /**
@@ -698,12 +816,13 @@
    * @private
    * @param  {Element} node derived from xml
    * @param  {object} obj recieves results
+   * @param  {object} options Parse options.
    * @return {void}
    */
-  function readNode(node, obj) {
+  function readNode(node, obj, options) {
     for (var n = node.firstElementChild; n; n = n.nextElementSibling) {
       if (parsers[n.localName]) {
-        parsers[n.localName](n, obj, n.localName);
+        parsers[n.localName](n, obj, n.localName, options);
       }
     }
   }
@@ -1557,21 +1676,6 @@
    * @property {PointSymbolizer[]} pointSymbolizers  pointsymbolizers, same as graphic prop from PointSymbolizer
    * @property {TextSymbolizer[]} textSymbolizers  textsymbolizers
    */
-
-  var IMAGE_LOADING = 'IMAGE_LOADING';
-  var IMAGE_LOADED = 'IMAGE_LOADED';
-  var IMAGE_ERROR = 'IMAGE_ERROR';
-
-  // SLD Spec: Default size for Marks without Size should be 6 pixels.
-  var DEFAULT_MARK_SIZE = 6; // pixels
-  // SLD Spec: Default size for ExternalGraphic with an unknown native size,
-  // like SVG without dimensions, should be 16 pixels.
-  var DEFAULT_EXTERNALGRAPHIC_SIZE = 16; // pixels
-
-  // QGIS Graphic stroke placement options
-  var PLACEMENT_DEFAULT = 'PLACEMENT_DEFAULT';
-  var PLACEMENT_FIRSTPOINT = 'PLACEMENT_FIRSTPOINT';
-  var PLACEMENT_LASTPOINT = 'PLACEMENT_LASTPOINT';
 
   /* eslint-disable no-continue */
 
@@ -3907,6 +4011,17 @@
 
     // Keep track of whether a callback has been registered per image url.
     var callbackRef = {};
+
+    //Todo: introduce context object outside returned function.
+    //Set context.getProperty outside returned function.
+    //Set context.convertMapResolution function outside returned function.
+    //Set context.resolution inside returned function at each invocation through context.convertMapResolution.
+    //(Note: setting context.resolution is a convenience, so it's not necessary to pass both context and mapResolution to the style functions).
+    //Pass context to OlStyler and then to getBla style functions instead of getProperty.
+    //Now all getBla functions returning a style can access the real resolution for non-pixel uoms.
+    //The graphicStroke render function can also get hold of the real resolution by:
+    //* Reading map resolution from renderContext.resolution.
+    //* Converting it into a real resolution via context.convertMapResolution.
 
     return function (feature, mapResolution) {
       // Determine resolution in meters/pixel.

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -189,6 +189,17 @@ export function createOlStyleFunction(featureTypeStyle, options = {}) {
   // Keep track of whether a callback has been registered per image url.
   const callbackRef = {};
 
+  //Todo: introduce context object outside returned function.
+  //Set context.getProperty outside returned function.
+  //Set context.convertMapResolution function outside returned function.
+  //Set context.resolution inside returned function at each invocation through context.convertMapResolution.
+  //(Note: setting context.resolution is a convenience, so it's not necessary to pass both context and mapResolution to the style functions).
+  //Pass context to OlStyler and then to getBla style functions instead of getProperty.
+  //Now all getBla functions returning a style can access the real resolution for non-pixel uoms.
+  //The graphicStroke render function can also get hold of the real resolution by:
+  //* Reading map resolution from renderContext.resolution.
+  //* Converting it into a real resolution via context.convertMapResolution.
+
   return (feature, mapResolution) => {
     // Determine resolution in meters/pixel.
     const resolution =

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -189,17 +189,6 @@ export function createOlStyleFunction(featureTypeStyle, options = {}) {
   // Keep track of whether a callback has been registered per image url.
   const callbackRef = {};
 
-  //Todo: introduce context object outside returned function.
-  //Set context.getProperty outside returned function.
-  //Set context.convertMapResolution function outside returned function.
-  //Set context.resolution inside returned function at each invocation through context.convertMapResolution.
-  //(Note: setting context.resolution is a convenience, so it's not necessary to pass both context and mapResolution to the style functions).
-  //Pass context to OlStyler and then to getBla style functions instead of getProperty.
-  //Now all getBla functions returning a style can access the real resolution for non-pixel uoms.
-  //The graphicStroke render function can also get hold of the real resolution by:
-  //* Reading map resolution from renderContext.resolution.
-  //* Converting it into a real resolution via context.convertMapResolution.
-
   return (feature, mapResolution) => {
     // Determine resolution in meters/pixel.
     const resolution =

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -1,3 +1,4 @@
+import { UOM_METRE, UOM_FOOT, UOM_PIXEL } from '../constants';
 import createFilter from './filter';
 
 /**
@@ -25,6 +26,49 @@ function addPropArray(node, obj, prop) {
   obj[property] = obj[property] || [];
   const item = {};
   readNode(node, item);
+  obj[property].push(item);
+}
+
+/**
+ * Parse symbolizer element and extract units of measure attribute.
+ * @param {Element} node the xml element to parse
+ * @param {object} obj  the object to modify
+ * @param {string} prop key on obj to hold array
+ */
+function addSymbolizer(node, obj, prop) {
+  const property = prop.toLowerCase();
+  obj[property] = obj[property] || [];
+  const item = {};
+
+  // Check and add if symbolizer node has uom attribute.
+  // If there is no uom attribute, default to pixel.
+  const uom = node.getAttribute('uom');
+  if (uom) {
+    switch (uom) {
+      // From symbology encoding spec:
+      // The following uom definitions are recommended to be used:
+      case 'http://www.opengeospatial.org/se/units/metre':
+        item.uom = UOM_METRE;
+        break;
+      case 'http://www.opengeospatial.org/se/units/foot':
+        item.uom = UOM_FOOT;
+        break;
+      case 'http://www.opengeospatial.org/se/units/pixel':
+        item.uom = UOM_PIXEL;
+        break;
+      default:
+        // eslint-disable-next-line no-console
+        console.warn(
+          'Unsupported uom attribute found, one of http://www.opengeospatial.org/se/units/(metre|feet|pixel) expected.'
+        );
+        item.uom = UOM_PIXEL;
+        break;
+    }
+  } else {
+    item.uom = UOM_PIXEL;
+  }
+
+  readNode(node, item); //TODO: pass uom down to readNode and all symbolizer parser functions
   obj[property].push(item);
 }
 
@@ -326,10 +370,10 @@ const FilterParsers = {
 };
 
 const SymbParsers = {
-  PolygonSymbolizer: addPropArray,
-  LineSymbolizer: addPropArray,
-  PointSymbolizer: addPropArray,
-  TextSymbolizer: addPropArray,
+  PolygonSymbolizer: addSymbolizer,
+  LineSymbolizer: addSymbolizer,
+  PointSymbolizer: addSymbolizer,
+  TextSymbolizer: addSymbolizer,
   Fill: addProp,
   Stroke: addProp,
   GraphicStroke: addProp,

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -1,4 +1,4 @@
-import { UOM_METRE, UOM_FOOT, UOM_PIXEL } from '../constants';
+import { UOM_METRE, UOM_FOOT, UOM_PIXEL, UOM_NONE } from '../constants';
 import createFilter from './filter';
 
 /**
@@ -13,6 +13,8 @@ const numericSvgProps = new Set([
   'fontSize',
 ]);
 
+const dimensionlessSvgProps = new Set(['strokeOpacity', 'fillOpacity']);
+
 /**
  * Generic parser for elements with maxOccurs > 1
  * it pushes result of readNode(node) to array on obj[prop]
@@ -20,12 +22,13 @@ const numericSvgProps = new Set([
  * @param {Element} node the xml element to parse
  * @param {object} obj  the object to modify
  * @param {string} prop key on obj to hold array
+ * @param {object} options Parse options.
  */
-function addPropArray(node, obj, prop) {
+function addPropArray(node, obj, prop, options) {
   const property = prop.toLowerCase();
   obj[property] = obj[property] || [];
   const item = {};
-  readNode(node, item);
+  readNode(node, item, options);
   obj[property].push(item);
 }
 
@@ -68,7 +71,10 @@ function addSymbolizer(node, obj, prop) {
     item.uom = UOM_PIXEL;
   }
 
-  readNode(node, item); //TODO: pass uom down to readNode and all symbolizer parser functions
+  readNode(node, item, {
+    // Note: text symbolizer units of measure are always pixel.
+    uom: property === 'textsymbolizer' ? UOM_PIXEL : item.uom,
+  });
   obj[property].push(item);
 }
 
@@ -79,11 +85,12 @@ function addSymbolizer(node, obj, prop) {
  * @param {Element} node the xml element to parse
  * @param {object} obj  the object to modify
  * @param {string} prop key on obj to hold empty object
+ * @param {object} options Parse options.
  */
-function addProp(node, obj, prop) {
+function addProp(node, obj, prop, options) {
   const property = prop.toLowerCase();
   obj[property] = {};
-  readNode(node, obj[property]);
+  readNode(node, obj[property], options);
 }
 
 /**
@@ -92,11 +99,12 @@ function addProp(node, obj, prop) {
  * @param {Element} node [description]
  * @param {object} obj  [description]
  * @param {string} prop [description]
- * @param {bool} [trimText] Trim whitespace from text content (default false).
+ * @param {object} options Parse options.
+ * @param {bool} [options.trimText] Trim whitespace from text content (default false).
  */
-function addPropWithTextContent(node, obj, prop, trimText = false) {
+function addPropWithTextContent(node, obj, prop, options) {
   const property = prop.toLowerCase();
-  if (trimText) {
+  if (options && options.trimText) {
     obj[property] = node.textContent.trim();
   } else {
     obj[property] = node.textContent;
@@ -106,6 +114,7 @@ function addPropWithTextContent(node, obj, prop, trimText = false) {
 /**
  * Assigns numeric value of text content to obj.prop.
  * Assigns NaN if the text value is not a valid text representation of a floating point number.
+ * If you need a value with unit of measure, use addParameterValueProp instead.
  * @private
  * @param {Element} node The XML node element.
  * @param {object} obj  The object to add the element value to.
@@ -126,17 +135,26 @@ function addNumericProp(node, obj, prop) {
  * @param {string} typeHint Expression type. Choose 'string' or 'number'.
  * @param {boolean} concatenateLiterals When true, and when all expressions are literals,
  * concatenate all literal expressions into a single string.
+ * @param {string} uom Unit of measure.
  * @return {Array<OGCExpression>|OGCExpression|string} Simplified version of the expression array.
  */
-function simplifyChildExpressions(expressions, typeHint, concatenateLiterals) {
+function simplifyChildExpressions(
+  expressions,
+  typeHint,
+  concatenateLiterals,
+  uom
+) {
   if (!Array.isArray(expressions)) {
     return expressions;
   }
 
-  // Replace each literal expression with its value.
+  // Replace each literal expression with its value, unless it has units of measure that are not pixels.
   const simplifiedExpressions = expressions
     .map(expression => {
-      if (expression.type === 'literal') {
+      if (
+        expression.type === 'literal' &&
+        !(expression.uom === UOM_METRE || expression.uom === UOM_FOOT)
+      ) {
         return expression.value;
       }
       return expression;
@@ -161,6 +179,7 @@ function simplifyChildExpressions(expressions, typeHint, concatenateLiterals) {
   return {
     type: 'expression',
     typeHint,
+    uom,
     children: simplifiedExpressions,
   };
 }
@@ -186,10 +205,11 @@ function simplifyChildExpressions(expressions, typeHint, concatenateLiterals) {
  * @param {object} obj Object to add XML node contents to.
  * @param {string} prop Property name on obj that will hold the parsed node contents.
  * @param {object} [options] Parse options.
- * @param {object} [options.skipEmptyNodes] Default true. If true, emtpy (whitespace-only) text nodes will me omitted in the result.
- * @param {object} [options.forceLowerCase] Default true. If true, convert prop name to lower case before adding it to obj.
- * @param {object} [options.typeHint] Default 'string'. When set to 'number', a simple literal value will be converted to a number.
- * @param {object} [options.concatenateLiterals] Default true. When true, and when all expressions are literals,
+ * @param {bool} [options.skipEmptyNodes] Default true. If true, emtpy (whitespace-only) text nodes will me omitted in the result.
+ * @param {bool} [options.forceLowerCase] Default true. If true, convert prop name to lower case before adding it to obj.
+ * @param {string} [options.typeHint] Default 'string'. When set to 'number', a simple literal value will be converted to a number.
+ * @param {bool} [options.concatenateLiterals] Default true. When true, and when all expressions are literals,
+ * @param {string} [options.uom] Unit of measure.
  * concatenate all literal expressions into a single string.
  */
 function addParameterValueProp(node, obj, prop, options = {}) {
@@ -198,6 +218,7 @@ function addParameterValueProp(node, obj, prop, options = {}) {
     forceLowerCase: true,
     typeHint: 'string',
     concatenateLiterals: true,
+    uom: UOM_NONE,
   };
 
   const parseOptions = {
@@ -232,6 +253,7 @@ function addParameterValueProp(node, obj, prop, options = {}) {
       // Parse child expressions, and add them to the comparison object.
       const parsed = {};
       addParameterValueProp(childNode, parsed, 'params', {
+        ...parseOptions,
         concatenateLiterals: false,
       });
       if (Array.isArray(parsed.params.children)) {
@@ -256,6 +278,7 @@ function addParameterValueProp(node, obj, prop, options = {}) {
       // Parse child expressions, and add them to the comparison object.
       const parsed = {};
       addParameterValueProp(childNode, parsed, 'params', {
+        ...parseOptions,
         concatenateLiterals: false,
       });
       if (Array.isArray(parsed.params.children)) {
@@ -294,15 +317,29 @@ function addParameterValueProp(node, obj, prop, options = {}) {
   let simplifiedValue = simplifyChildExpressions(
     childExpressions,
     parseOptions.typeHint,
-    parseOptions.concatenateLiterals
+    parseOptions.concatenateLiterals,
+    parseOptions.uom
   );
 
   // Convert simple string value to number if type hint is number.
+  // Keep full literal expression if unit of measure is in metre or foot.
   if (
     typeof simplifiedValue === 'string' &&
     parseOptions.typeHint === 'number'
   ) {
-    simplifiedValue = parseFloat(simplifiedValue);
+    // If numbers are written with 'px' at the end, they override the symbolizer's own uom.
+    const uom =
+      simplifiedValue.indexOf('px') > -1 ? UOM_PIXEL : parseOptions.uom;
+    if (uom === UOM_METRE || uom === UOM_FOOT) {
+      simplifiedValue = {
+        type: 'literal',
+        typeHint: 'number',
+        value: parseFloat(simplifiedValue),
+        uom,
+      };
+    } else {
+      simplifiedValue = parseFloat(simplifiedValue);
+    }
   }
 
   obj[propertyName] = simplifiedValue;
@@ -310,6 +347,19 @@ function addParameterValueProp(node, obj, prop, options = {}) {
 
 function addNumericParameterValueProp(node, obj, prop, options = {}) {
   addParameterValueProp(node, obj, prop, { ...options, typeHint: 'number' });
+}
+
+function addDimensionlessNumericParameterValueProp(
+  node,
+  obj,
+  prop,
+  options = {}
+) {
+  addParameterValueProp(node, obj, prop, {
+    ...options,
+    typeHint: 'number',
+    uom: UOM_NONE,
+  });
 }
 
 /**
@@ -337,8 +387,11 @@ function getBool(element, tagName) {
  * @param  {object} obj
  * @param  {string} prop
  * @param  {string} parameterGroup Name of parameter group.
+ * @param  {object} options Parse options.
  */
-function addParameterValue(element, obj, prop, parameterGroup) {
+function addParameterValue(element, obj, prop, parameterGroup, options) {
+  const parseOptions = { ...options };
+
   obj[parameterGroup] = obj[parameterGroup] || {};
   const name = element
     .getAttribute('name')
@@ -346,17 +399,24 @@ function addParameterValue(element, obj, prop, parameterGroup) {
     .replace(/-(.)/g, (match, group1) => group1.toUpperCase());
 
   // Flag certain SVG parameters as numeric.
+  // Some SVG parameters are always dimensionless (like opacity).
   let typeHint = 'string';
+  let uom = parseOptions.uom;
   if (parameterGroup === 'styling') {
     if (numericSvgProps.has(name)) {
       typeHint = 'number';
     }
+    if (dimensionlessSvgProps.has(name)) {
+      uom = UOM_NONE;
+    }
   }
 
   addParameterValueProp(element, obj[parameterGroup], name, {
+    ...options,
     skipEmptyNodes: true,
     forceLowerCase: false,
     typeHint,
+    uom,
   });
 }
 
@@ -377,14 +437,18 @@ const SymbParsers = {
   Fill: addProp,
   Stroke: addProp,
   GraphicStroke: addProp,
-  GraphicFill: addProp,
+  GraphicFill: (node, obj, prop, options) =>
+    addProp(node, obj, prop, { ...options, uom: UOM_PIXEL }),
   Graphic: addProp,
   ExternalGraphic: addProp,
   Gap: addNumericParameterValueProp,
   InitialGap: addNumericParameterValueProp,
   Mark: addProp,
-  Label: (node, obj, prop) =>
-    addParameterValueProp(node, obj, prop, { skipEmptyNodes: false }),
+  Label: (node, obj, prop, options) =>
+    addParameterValueProp(node, obj, prop, {
+      ...options,
+      skipEmptyNodes: false,
+    }),
   Halo: addProp,
   Font: addProp,
   Radius: addNumericParameterValueProp,
@@ -393,25 +457,25 @@ const SymbParsers = {
   LinePlacement: addProp,
   PerpendicularOffset: addNumericParameterValueProp,
   AnchorPoint: addProp,
-  AnchorPointX: addNumericParameterValueProp,
-  AnchorPointY: addNumericParameterValueProp,
-  Opacity: addNumericParameterValueProp,
-  Rotation: addNumericParameterValueProp,
+  AnchorPointX: addDimensionlessNumericParameterValueProp,
+  AnchorPointY: addDimensionlessNumericParameterValueProp,
+  Opacity: addDimensionlessNumericParameterValueProp,
+  Rotation: addDimensionlessNumericParameterValueProp,
   Displacement: addProp,
   DisplacementX: addNumericParameterValueProp,
   DisplacementY: addNumericParameterValueProp,
   Size: addNumericParameterValueProp,
   WellKnownName: addPropWithTextContent,
   MarkIndex: addNumericProp,
-  VendorOption: (element, obj, prop) =>
-    addParameterValue(element, obj, prop, 'vendoroptions'),
+  VendorOption: (element, obj, prop, options) =>
+    addParameterValue(element, obj, prop, 'vendoroptions', options),
   OnlineResource: (element, obj) => {
     obj.onlineresource = element.getAttribute('xlink:href');
   },
-  CssParameter: (element, obj, prop) =>
-    addParameterValue(element, obj, prop, 'styling'),
-  SvgParameter: (element, obj, prop) =>
-    addParameterValue(element, obj, prop, 'styling'),
+  CssParameter: (element, obj, prop, options) =>
+    addParameterValue(element, obj, prop, 'styling', options),
+  SvgParameter: (element, obj, prop, options) =>
+    addParameterValue(element, obj, prop, 'styling', options),
 };
 
 /**
@@ -463,12 +527,13 @@ const parsers = {
  * @private
  * @param  {Element} node derived from xml
  * @param  {object} obj recieves results
+ * @param  {object} options Parse options.
  * @return {void}
  */
-function readNode(node, obj) {
+function readNode(node, obj, options) {
   for (let n = node.firstElementChild; n; n = n.nextElementSibling) {
     if (parsers[n.localName]) {
-      parsers[n.localName](n, obj, n.localName);
+      parsers[n.localName](n, obj, n.localName, options);
     }
   }
 }

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -41,7 +41,7 @@ function addPropArray(node, obj, prop, options) {
 function addSymbolizer(node, obj, prop) {
   const property = prop.toLowerCase();
   obj[property] = obj[property] || [];
-  const item = {};
+  const item = { type: 'symbolizer' };
 
   // Check and add if symbolizer node has uom attribute.
   // If there is no uom attribute, default to pixel.

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,3 +12,12 @@ export const DEFAULT_EXTERNALGRAPHIC_SIZE = 16; // pixels
 export const PLACEMENT_DEFAULT = 'PLACEMENT_DEFAULT';
 export const PLACEMENT_FIRSTPOINT = 'PLACEMENT_FIRSTPOINT';
 export const PLACEMENT_LASTPOINT = 'PLACEMENT_LASTPOINT';
+
+// Supported units of measure
+export const UOM_METRE = 'metre';
+export const UOM_FOOT = 'foot';
+export const UOM_PIXEL = 'pixel';
+// None = number is dimensionless.
+export const UOM_NONE = 'none';
+
+export const METRES_PER_FOOT = 0.3048;

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -1,5 +1,4 @@
 /* global describe it expect before beforeEach */
-import Reader from '../src/Reader';
 import { sld } from './data/test.sld';
 import { sld11 } from './data/test11.sld';
 import { dynamicSld } from './data/dynamic.sld';
@@ -10,8 +9,11 @@ import { multipleSymbolizersSld } from './data/multiple-symbolizers.sld';
 import { staticPolygonSymbolizerSld } from './data/static-polygon-symbolizer.sld';
 import { dynamicPolygonSymbolizerSld } from './data/dynamic-polygon-symbolizer.sld';
 import { graphicStrokeVendorOption } from './data/graphicstroke-vendoroption.sld';
-import sldWithUom from './data/sld-with-uom';
-import { UOM_METRE, UOM_PIXEL } from '../src/constants';
+import { sldWithUom } from './data/sld-with-uom';
+
+import { UOM_METRE } from '../src/constants';
+
+import Reader from '../src/Reader';
 
 let result;
 
@@ -531,7 +533,7 @@ describe('SVG style parameters', () => {
     });
   });
 
-  describe.only('Parse units of measure', () => {
+  describe('Parse units of measure', () => {
     let pointSymbolizer;
     let lineSymbolizer;
     let polygonSymbolizer;
@@ -562,18 +564,15 @@ describe('SVG style parameters', () => {
     });
 
     it('PointSymbolizer stroke width overrides uom by appending px', () => {
-      expect(
-        pointSymbolizer.graphic.mark.stroke.styling.strokeWidth
-      ).to.deep.equal({
-        type: 'literal',
-        typeHint: 'number',
-        value: 2,
-        uom: UOM_PIXEL,
-      });
+      expect(pointSymbolizer.graphic.mark.stroke.styling.strokeWidth).to.equal(
+        2
+      );
     });
 
     it('Opacity is always a dimensionless number', () => {
-      expect(pointSymbolizer.graphic.mark.fill.styling.fillOpacity).to.equal(0.8);
+      expect(pointSymbolizer.graphic.mark.fill.styling.fillOpacity).to.equal(
+        0.8
+      );
     });
 
     it('LineSymbolizer stroke width in metres', () => {
@@ -590,7 +589,7 @@ describe('SVG style parameters', () => {
         type: 'literal',
         typeHint: 'number',
         value: 12,
-        uom: UOM_PIXEL,
+        uom: UOM_METRE,
       });
     });
 
@@ -615,21 +614,11 @@ describe('SVG style parameters', () => {
     });
 
     it('Text symbolizer font size always pixel', () => {
-      expect(textSymbolizer.font.styling.fontSize).to.deep.equal({
-        type: 'literal',
-        typeHint: 'number',
-        value: 13,
-        uom: UOM_PIXEL,
-      });
+      expect(textSymbolizer.font.styling.fontSize).to.equal(13);
     });
 
     it('Text symbolizer halo radius always pixel', () => {
-      expect(textSymbolizer.halo.radius).to.deep.equal({
-        type: 'literal',
-        typeHint: 'number',
-        value: 2,
-        uom: UOM_PIXEL,
-      });
+      expect(textSymbolizer.halo.radius).to.equal(2);
     });
 
     it('Text symbolizer anchor point X/Y always a dimensionless number', () => {
@@ -639,22 +628,12 @@ describe('SVG style parameters', () => {
     });
 
     it('Polygon graphic fill mark size always pixel', () => {
-      expect(polygonSymbolizer.fill.graphicfill.graphic.size).to.deep.equal({
-        type: 'literal',
-        typeHint: 'number',
-        value: 8,
-        uom: UOM_PIXEL,
-      });
+      expect(polygonSymbolizer.fill.graphicfill.graphic.size).to.equal(8);
     });
 
     it('Polygon graphic fill stroke width always pixel', () => {
       const graphicFillMark = polygonSymbolizer.fill.graphicfill.graphic.mark;
-      expect(graphicFillMark.stroke.styling.strokeWidth).to.deep.equal({
-        type: 'literal',
-        typeHint: 'number',
-        value: 1,
-        uom: UOM_PIXEL,
-      });
+      expect(graphicFillMark.stroke.styling.strokeWidth).to.equal(1);
     });
   });
 });

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -10,6 +10,8 @@ import { multipleSymbolizersSld } from './data/multiple-symbolizers.sld';
 import { staticPolygonSymbolizerSld } from './data/static-polygon-symbolizer.sld';
 import { dynamicPolygonSymbolizerSld } from './data/dynamic-polygon-symbolizer.sld';
 import { graphicStrokeVendorOption } from './data/graphicstroke-vendoroption.sld';
+import sldWithUom from './data/sld-with-uom';
+import { UOM_METRE, UOM_PIXEL } from '../src/constants';
 
 let result;
 
@@ -526,6 +528,133 @@ describe('SVG style parameters', () => {
     });
     it('Stroke width should be number', () => {
       expect(strokeStyle.strokeWidth.typeHint).to.equal('number');
+    });
+  });
+
+  describe.only('Parse units of measure', () => {
+    let pointSymbolizer;
+    let lineSymbolizer;
+    let polygonSymbolizer;
+    let textSymbolizer;
+    beforeEach(() => {
+      const parsedSld = Reader(sldWithUom);
+      const fts = parsedSld.layers[0].styles[0].featuretypestyles[0];
+      pointSymbolizer = fts.rules[0].pointsymbolizer[0];
+      textSymbolizer = fts.rules[0].textsymbolizer[0];
+      lineSymbolizer = fts.rules[1].linesymbolizer[0];
+      polygonSymbolizer = fts.rules[2].polygonsymbolizer[0];
+    });
+
+    it('Parse uom attribute for symbolizer elements', () => {
+      expect(pointSymbolizer.uom).to.equal(UOM_METRE);
+      expect(textSymbolizer.uom).to.equal(UOM_METRE);
+      expect(lineSymbolizer.uom).to.equal(UOM_METRE);
+      expect(polygonSymbolizer.uom).to.equal(UOM_METRE);
+    });
+
+    it('PointSymbolizer size in metres', () => {
+      expect(pointSymbolizer.graphic.size).to.deep.equal({
+        type: 'literal',
+        typeHint: 'number',
+        value: 10,
+        uom: UOM_METRE,
+      });
+    });
+
+    it('PointSymbolizer stroke width overrides uom by appending px', () => {
+      expect(
+        pointSymbolizer.graphic.mark.stroke.styling.strokeWidth
+      ).to.deep.equal({
+        type: 'literal',
+        typeHint: 'number',
+        value: 2,
+        uom: UOM_PIXEL,
+      });
+    });
+
+    it('Opacity is always a dimensionless number', () => {
+      expect(pointSymbolizer.graphic.mark.fill.styling.fillOpacity).to.equal(0.8);
+    });
+
+    it('LineSymbolizer stroke width in metres', () => {
+      expect(lineSymbolizer.stroke.styling.strokeWidth).to.deep.equal({
+        type: 'literal',
+        typeHint: 'number',
+        value: 3,
+        uom: UOM_METRE,
+      });
+    });
+
+    it('LineSymbolizer graphic stroke gap inherits uom', () => {
+      expect(lineSymbolizer.graphicstroke.gap).to.deep.equal({
+        type: 'literal',
+        typeHint: 'number',
+        value: 12,
+        uom: UOM_PIXEL,
+      });
+    });
+
+    it('LineSymbolizer graphic stroke mark size inherits uom', () => {
+      const { graphic } = lineSymbolizer.graphicstroke;
+      expect(graphic.size).to.deep.equal({
+        type: 'literal',
+        typeHint: 'number',
+        value: 4,
+        uom: UOM_METRE,
+      });
+    });
+
+    it('LineSymbolizer graphic stroke mark stroke width inherits uom', () => {
+      const { mark } = lineSymbolizer.graphicstroke.graphic;
+      expect(mark.stroke.styling.strokeWidth).to.deep.equal({
+        type: 'literal',
+        typeHint: 'number',
+        value: 2,
+        uom: UOM_METRE,
+      });
+    });
+
+    it('Text symbolizer font size always pixel', () => {
+      expect(textSymbolizer.font.styling.fontSize).to.deep.equal({
+        type: 'literal',
+        typeHint: 'number',
+        value: 13,
+        uom: UOM_PIXEL,
+      });
+    });
+
+    it('Text symbolizer halo radius always pixel', () => {
+      expect(textSymbolizer.halo.radius).to.deep.equal({
+        type: 'literal',
+        typeHint: 'number',
+        value: 2,
+        uom: UOM_PIXEL,
+      });
+    });
+
+    it('Text symbolizer anchor point X/Y always a dimensionless number', () => {
+      const { anchorpoint } = textSymbolizer.labelplacement.pointplacement;
+      expect(anchorpoint.anchorpointx).to.equal(0.5);
+      expect(anchorpoint.anchorpointy).to.equal(0.5);
+    });
+
+    it('Polygon graphic fill mark size always pixel', () => {
+      expect(polygonSymbolizer.fill.graphicfill.graphic.size).to.deep.equal({
+        type: 'literal',
+        typeHint: 'number',
+        value: 8,
+        uom: UOM_PIXEL,
+      });
+    });
+
+    it('Polygon graphic fill stroke width always pixel', () => {
+      const graphicFillMark = polygonSymbolizer.fill.graphicfill.graphic.mark;
+      expect(graphicFillMark.stroke.styling.strokeWidth).to.deep.equal({
+        type: 'literal',
+        typeHint: 'number',
+        value: 1,
+        uom: UOM_PIXEL,
+      });
     });
   });
 });

--- a/test/data/sld-with-uom.js
+++ b/test/data/sld-with-uom.js
@@ -1,0 +1,104 @@
+export const sldWithUom = `<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd"
+  xmlns:se="http://www.opengis.net/se">
+  <NamedLayer>
+    <UserStyle>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:PointSymbolizer uom="http://www.opengeospatial.org/se/units/metre">
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+                  <se:SvgParameter name="fill-opacity">0.8</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke>
+                  <se:SvgParameter name="stroke">#880000</se:SvgParameter>
+                  <se:SvgParameter name="stroke-width">2px</se:SvgParameter>
+                </se:Stroke>
+              </se:Mark>
+              <se:Size>10</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+          <se:TextSymbolizer uom="http://www.opengeospatial.org/se/units/metre">
+            <se:Label>
+              <ogc:PropertyName>provincienaam</ogc:PropertyName>
+            </se:Label>
+            <se:Font>
+              <se:SvgParameter name="font-family">Noto Sans</se:SvgParameter>
+              <se:SvgParameter name="font-size">13</se:SvgParameter>
+            </se:Font>
+            <se:LabelPlacement>
+              <se:PointPlacement>
+                <se:AnchorPoint>
+                  <se:AnchorPointX>0.5</se:AnchorPointX>
+                  <se:AnchorPointY>0.5</se:AnchorPointY>
+                </se:AnchorPoint>
+              </se:PointPlacement>
+            </se:LabelPlacement>
+            <se:Halo>
+              <se:Radius>2</se:Radius>
+              <se:Fill>
+                <se:SvgParameter name="fill">#FFFFFF</se:SvgParameter>
+              </se:Fill>
+            </se:Halo>
+            <se:Fill>
+              <se:SvgParameter name="fill">#000000</se:SvgParameter>
+            </se:Fill>
+          </se:TextSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <se:LineSymbolizer uom="http://www.opengeospatial.org/se/units/metre">
+            <se:Stroke>
+              <se:SvgParameter name="stroke">#00AA00</se:SvgParameter>
+              <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+            </se:Stroke>
+            <se:GraphicStroke>
+              <se:Graphic>
+                <se:Mark>
+                  <se:WellKnownName>square</se:WellKnownName>
+                  <se:Fill>
+                    <se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+                  </se:Fill>
+                  <se:Stroke>
+                    <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+                    <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+                  </se:Stroke>
+                </se:Mark>
+                <se:Size>4</se:Size>
+                <se:Rotation>45</se:Rotation>
+              </se:Graphic>
+              <se:Gap>
+                <ogc:Literal>12</ogc:Literal>
+              </se:Gap>
+            </se:GraphicStroke>
+          </se:LineSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <se:PolygonSymbolizer uom="http://www.opengeospatial.org/se/units/metre">
+            <se:Fill>
+              <se:GraphicFill>
+                <se:Graphic>
+                  <se:Mark>
+                    <se:WellKnownName>cross</se:WellKnownName>
+                    <se:Stroke>
+                      <se:SvgParameter name="stroke">#3544ea</se:SvgParameter>
+                      <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+                    </se:Stroke>
+                  </se:Mark>
+                  <se:Size>8</se:Size>
+                </se:Graphic>
+              </se:GraphicFill>
+            </se:Fill>
+          </se:PolygonSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>`;
+
+export default sldWithUom;

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -1,0 +1,58 @@
+function appendPropToPath(path, propName) {
+  if (path === '') {
+    return propName;
+  }
+  return `${path}.${propName}`;
+}
+
+function appendArrayIndexToPath(path, index) {
+  return `${path}[${index}]`;
+}
+
+function _validateObjectProperties(prop, propName, path, validateFn, errors) {
+  let currentPath = path;
+  try {
+    validateFn(prop, propName);
+    if (Array.isArray(prop)) {
+      for (let k = 0; k < prop.length; k += 1) {
+        currentPath = appendArrayIndexToPath(path, k);
+        _validateObjectProperties(
+          prop[k],
+          propName,
+          currentPath,
+          validateFn,
+          errors
+        );
+      }
+    } else if (typeof prop === 'object') {
+      const childProps = Object.keys(prop);
+      childProps.forEach(childPropName => {
+        currentPath = appendPropToPath(path, childPropName);
+        _validateObjectProperties(
+          prop[childPropName],
+          childPropName,
+          currentPath,
+          validateFn,
+          errors
+        );
+      });
+    }
+  } catch (err) {
+    errors.push({ path: currentPath, errorMessage: err.toString() });
+  }
+}
+
+/**
+ * This function validates object properties recursively and returns an array of validation errors,
+ * including a path to the failing property.
+ * @param {object} obj Test object (or array).
+ * @param {object} nodeName Root node name.
+ * @param {Function} validateFn Function that tests an object (or property thereof)
+ * and throws an error if the test fails.
+ */
+// eslint-disable-next-line import/prefer-default-export
+export function validateObjectProperties(obj, rootName, validateFn) {
+  const errors = [];
+  _validateObjectProperties(obj, rootName, '', validateFn, errors);
+  return errors;
+}


### PR DESCRIPTION
Add support for parsing units of measure on a symbolizer. The following uom attribute values are supported:
```
http://www.opengeospatial.org/se/units/metre
http://www.opengeospatial.org/se/units/foot
http://www.opengeospatial.org/se/units/pixel
```

If a symbolizer has a valid uom attribute, it's added as `uom: 'metre'`, `uom: 'foot'`, or `uom 'pixel'` to the parsed symbolizer object. Any numeric literals that are in metres or feet are parsed (for example) as:
```
{
  type: 'literal',
  typeHint: 'number',
  value: 42,
  uom: 'metre',
}
```
instead of plain numbers.

It's possible to override a symbolizer's uom to pixels by adding `px` to the end of a numeric value.
```
<se:SvgParameter name="stroke-width">2px</se:SvgParameter>
```
