### PR TITLE
Introduce context

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ GraphicFill and PerpendicularOffset are not supported.
 
 #### Note about GraphicStroke
 
-ExternalGraphic is mostly supported with these caveats:
-
-- Always add a Size-element, even if using an ExternalGraphic instead of a Mark.
-- SLD V1.0.0 does not officially support the Gap property. For this, SLDReader implements the same workaround that Geoserver uses. You can use the `stroke-dasharray` parameter to add a gap between stroke marks. To do this, use a dash array with two parameters: the first parameter being the size of the graphic and the second being the gap size. See the " GraphicStroke: ExternalGraphic" example.
+- It's not possible to use property-dependent values inside a GraphicStroke symbolizer.
+- ExternalGraphic is mostly supported with these caveats:
+  - Always add a Size-element, even if using an ExternalGraphic instead of a Mark.
+  - SLD V1.0.0 does not officially support the Gap property. For this, SLDReader implements the same workaround that Geoserver uses. You can use the `stroke-dasharray` parameter to add a gap between stroke marks. To do this, use a dash array with two parameters: the first parameter being the size of the graphic and the second being the gap size. See the " GraphicStroke: ExternalGraphic" example.
 
 #### GraphicStroke vendor options
 
@@ -94,6 +94,8 @@ The following WellKnownNames used by QGIS simple fills can be used as well:
 - slash
 - backslash
 - brush://dense1 (till dense7)
+
+**Note:** It's not possible to use property-dependent values for inside a GraphicFill element.
 
 #### TextSymbolizer
 

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -1100,7 +1100,7 @@
       value === '' ||
       Number.isNaN(value)
     ) {
-      return defaultValue;
+      value = defaultValue;
     }
 
     // Convert value to number if expression is flagged as numeric.

--- a/docs/assets/sldreader.js
+++ b/docs/assets/sldreader.js
@@ -2900,10 +2900,9 @@
    * to be used inside an OpenLayers Style.renderer function.
    * @private
    * @param {LineSymbolizer} linesymbolizer SLD line symbolizer object.
-   * @param {Function} getProperty A property getter: (feature, propertyName) => property value.
    * @returns {ol/style/Style~RenderFunction} A style renderer function (pixelCoords, renderState) => void.
    */
-  function getGraphicStrokeRenderer(linesymbolizer, getProperty) {
+  function getGraphicStrokeRenderer(linesymbolizer) {
     if (!(linesymbolizer.stroke && linesymbolizer.stroke.graphicstroke)) {
       throw new Error(
         'getGraphicStrokeRenderer error: symbolizer.stroke.graphicstroke null or undefined.'
@@ -2947,7 +2946,7 @@
       var pointStyle = getPointStyle(
         graphicstroke,
         renderState.feature,
-        getProperty
+        null
       );
 
       // Calculate graphic spacing.
@@ -2960,7 +2959,7 @@
         evaluate(
           graphicSizeExpression,
           renderState.feature,
-          getProperty,
+          null,
           defaultGraphicSize
         )
       );
@@ -2983,10 +2982,9 @@
    * Create an OpenLayers style for rendering line symbolizers with a GraphicStroke.
    * @private
    * @param {LineSymbolizer} linesymbolizer SLD line symbolizer object.
-   * @param {Function} getProperty A property getter: (feature, propertyName) => property value.
    * @returns {ol/style/Style} An OpenLayers style instance.
    */
-  function getGraphicStrokeStyle(linesymbolizer, getProperty) {
+  function getGraphicStrokeStyle(linesymbolizer) {
     if (!(linesymbolizer.stroke && linesymbolizer.stroke.graphicstroke)) {
       throw new Error(
         'getGraphicStrokeStyle error: linesymbolizer.stroke.graphicstroke null or undefined.'
@@ -2994,7 +2992,7 @@
     }
 
     return new style.Style({
-      renderer: getGraphicStrokeRenderer(linesymbolizer, getProperty),
+      renderer: getGraphicStrokeRenderer(linesymbolizer),
     });
   }
 

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -45,18 +45,18 @@ function compare(a, b, matchcase) {
   return aString.toLowerCase().localeCompare(bString.toLowerCase());
 }
 
-function propertyIsNull(comparison, feature, getProperty) {
-  const value = evaluate(comparison.expression, feature, getProperty);
+function propertyIsNull(comparison, feature, context) {
+  const value = evaluate(comparison.expression, feature, context);
   return isNullOrUndefined(value);
 }
 
-function propertyIsLessThan(comparison, feature, getProperty) {
-  const value1 = evaluate(comparison.expression1, feature, getProperty);
+function propertyIsLessThan(comparison, feature, context) {
+  const value1 = evaluate(comparison.expression1, feature, context);
   if (isNullOrUndefined(value1)) {
     return false;
   }
 
-  const value2 = evaluate(comparison.expression2, feature, getProperty);
+  const value2 = evaluate(comparison.expression2, feature, context);
   if (isNullOrUndefined(value2)) {
     return false;
   }
@@ -64,13 +64,13 @@ function propertyIsLessThan(comparison, feature, getProperty) {
   return compare(value1, value2) < 0;
 }
 
-function propertyIsGreaterThan(comparison, feature, getProperty) {
-  const value1 = evaluate(comparison.expression1, feature, getProperty);
+function propertyIsGreaterThan(comparison, feature, context) {
+  const value1 = evaluate(comparison.expression1, feature, context);
   if (isNullOrUndefined(value1)) {
     return false;
   }
 
-  const value2 = evaluate(comparison.expression2, feature, getProperty);
+  const value2 = evaluate(comparison.expression2, feature, context);
   if (isNullOrUndefined(value2)) {
     return false;
   }
@@ -78,8 +78,8 @@ function propertyIsGreaterThan(comparison, feature, getProperty) {
   return compare(value1, value2) > 0;
 }
 
-function propertyIsBetween(comparison, feature, getProperty) {
-  const value = evaluate(comparison.expression, feature, getProperty);
+function propertyIsBetween(comparison, feature, context) {
+  const value = evaluate(comparison.expression, feature, context);
   if (isNullOrUndefined(value)) {
     return false;
   }
@@ -87,7 +87,7 @@ function propertyIsBetween(comparison, feature, getProperty) {
   const lowerBoundary = evaluate(
     comparison.lowerboundary,
     feature,
-    getProperty
+    context
   );
   if (isNullOrUndefined(lowerBoundary)) {
     return false;
@@ -96,7 +96,7 @@ function propertyIsBetween(comparison, feature, getProperty) {
   const upperBoundary = evaluate(
     comparison.upperboundary,
     feature,
-    getProperty
+    context
   );
   if (isNullOrUndefined(upperBoundary)) {
     return false;
@@ -107,13 +107,13 @@ function propertyIsBetween(comparison, feature, getProperty) {
   );
 }
 
-function propertyIsEqualTo(comparison, feature, getProperty) {
-  const value1 = evaluate(comparison.expression1, feature, getProperty);
+function propertyIsEqualTo(comparison, feature, context) {
+  const value1 = evaluate(comparison.expression1, feature, context);
   if (isNullOrUndefined(value1)) {
     return false;
   }
 
-  const value2 = evaluate(comparison.expression2, feature, getProperty);
+  const value2 = evaluate(comparison.expression2, feature, context);
   if (isNullOrUndefined(value2)) {
     return false;
   }
@@ -133,18 +133,18 @@ function propertyIsEqualTo(comparison, feature, getProperty) {
 // Watch out! Null-ish values should not pass propertyIsNotEqualTo,
 // just like in databases.
 // This means that PropertyIsNotEqualTo is not the same as NOT(PropertyIsEqualTo).
-function propertyIsNotEqualTo(comparison, feature, getProperty) {
-  const value1 = evaluate(comparison.expression1, feature, getProperty);
+function propertyIsNotEqualTo(comparison, feature, context) {
+  const value1 = evaluate(comparison.expression1, feature, context);
   if (isNullOrUndefined(value1)) {
     return false;
   }
 
-  const value2 = evaluate(comparison.expression2, feature, getProperty);
+  const value2 = evaluate(comparison.expression2, feature, context);
   if (isNullOrUndefined(value2)) {
     return false;
   }
 
-  return !propertyIsEqualTo(comparison, feature, getProperty);
+  return !propertyIsEqualTo(comparison, feature, context);
 }
 
 /**
@@ -152,16 +152,16 @@ function propertyIsNotEqualTo(comparison, feature, getProperty) {
  * @private
  * @param {object} comparison filter object for operator 'propertyislike'
  * @param {string|number} value Feature property value.
- * @param {object} getProperty A function with parameters (feature, propertyName) to extract
+ * @param {EvaluationContext} context Evaluation context.
  * the value of a property from a feature.
  */
-function propertyIsLike(comparison, feature, getProperty) {
-  const value = evaluate(comparison.expression1, feature, getProperty);
+function propertyIsLike(comparison, feature, context) {
+  const value = evaluate(comparison.expression1, feature, context);
   if (isNullOrUndefined(value)) {
     return false;
   }
 
-  const pattern = evaluate(comparison.expression2, feature, getProperty);
+  const pattern = evaluate(comparison.expression2, feature, context);
   if (isNullOrUndefined(pattern)) {
     return false;
   }
@@ -201,36 +201,35 @@ function propertyIsLike(comparison, feature, getProperty) {
  * @private
  * @param  {Filter} comparison A comparison filter object.
  * @param  {object} feature A feature object.
- * @param  {Function} getProperty A function with parameters (feature, propertyName)
- * to extract a single property value from a feature.
+ * @param {EvaluationContext} context Evaluation context.
  * @return {bool}  does feature fullfill comparison
  */
-function doComparison(comparison, feature, getProperty) {
+function doComparison(comparison, feature, context) {
   switch (comparison.operator) {
     case 'propertyislessthan':
-      return propertyIsLessThan(comparison, feature, getProperty);
+      return propertyIsLessThan(comparison, feature, context);
     case 'propertyisequalto':
-      return propertyIsEqualTo(comparison, feature, getProperty);
+      return propertyIsEqualTo(comparison, feature, context);
     case 'propertyislessthanorequalto':
       return (
-        propertyIsEqualTo(comparison, feature, getProperty) ||
-        propertyIsLessThan(comparison, feature, getProperty)
+        propertyIsEqualTo(comparison, feature, context) ||
+        propertyIsLessThan(comparison, feature, context)
       );
     case 'propertyisnotequalto':
-      return propertyIsNotEqualTo(comparison, feature, getProperty);
+      return propertyIsNotEqualTo(comparison, feature, context);
     case 'propertyisgreaterthan':
-      return propertyIsGreaterThan(comparison, feature, getProperty);
+      return propertyIsGreaterThan(comparison, feature, context);
     case 'propertyisgreaterthanorequalto':
       return (
-        propertyIsEqualTo(comparison, feature, getProperty) ||
-        propertyIsGreaterThan(comparison, feature, getProperty)
+        propertyIsEqualTo(comparison, feature, context) ||
+        propertyIsGreaterThan(comparison, feature, context)
       );
     case 'propertyisbetween':
-      return propertyIsBetween(comparison, feature, getProperty);
+      return propertyIsBetween(comparison, feature, context);
     case 'propertyisnull':
-      return propertyIsNull(comparison, feature, getProperty);
+      return propertyIsNull(comparison, feature, context);
     case 'propertyislike':
-      return propertyIsLike(comparison, feature, getProperty);
+      return propertyIsLike(comparison, feature, context);
     default:
       throw new Error(`Unkown comparison operator ${comparison.operator}`);
   }
@@ -247,58 +246,22 @@ function doFIDFilter(fids, featureId) {
 }
 
 /**
- * @private
- * Get feature properties from a GeoJSON feature.
- * @param {object} feature GeoJSON feature.
- * @returns {object} Feature properties.
- *
- */
-function getGeoJSONProperty(feature, propertyName) {
-  return feature.properties[propertyName];
-}
-
-/**
- * @private
- * Gets feature id from a GeoJSON feature.
- * @param {object} feature GeoJSON feature.
- * @returns {number|string} Feature ID.
- */
-function getGeoJSONFeatureId(feature) {
-  return feature.id;
-}
-
-/**
  * Calls functions from Filter object to test if feature passes filter.
  * Functions are called with filter part they match and feature.
  * @private
  * @param  {Filter} filter
  * @param  {object} feature feature
- * @param  {object} options Custom filter options.
- * @param  {Function} options.getProperty An optional function with parameters (feature, propertyName)
- * that can be used to extract properties from a feature.
- * When not given, properties are read from feature.properties directly.
- * @param  {Function} options.getFeatureId An optional function to extract the feature id from a feature.
- * When not given, feature id is read from feature.id.
+ * @param {EvaluationContext} context Evaluation context.
  * @return {boolean} True if the feature passes the conditions described by the filter object.
  */
-export function filterSelector(filter, feature, options = {}) {
-  const getProperty =
-    typeof options.getProperty === 'function'
-      ? options.getProperty
-      : getGeoJSONProperty;
-
-  const getFeatureId =
-    typeof options.getFeatureId === 'function'
-      ? options.getFeatureId
-      : getGeoJSONFeatureId;
-
+export function filterSelector(filter, feature, context) {
   const { type } = filter;
   switch (type) {
     case 'featureid':
-      return doFIDFilter(filter.fids, getFeatureId(feature));
+      return doFIDFilter(filter.fids, context.getId(feature));
 
     case 'comparison':
-      return doComparison(filter, feature, getProperty);
+      return doComparison(filter, feature, context);
 
     case 'and': {
       if (!filter.predicates) {
@@ -311,7 +274,7 @@ export function filterSelector(filter, feature, options = {}) {
       }
 
       return filter.predicates.every(predicate =>
-        filterSelector(predicate, feature, options)
+        filterSelector(predicate, feature, context)
       );
     }
 
@@ -321,7 +284,7 @@ export function filterSelector(filter, feature, options = {}) {
       }
 
       return filter.predicates.some(predicate =>
-        filterSelector(predicate, feature, options)
+        filterSelector(predicate, feature, context)
       );
     }
 
@@ -330,7 +293,7 @@ export function filterSelector(filter, feature, options = {}) {
         throw new Error('Not filter must have predicate.');
       }
 
-      return !filterSelector(filter.predicate, feature, options);
+      return !filterSelector(filter.predicate, feature, context);
     }
 
     default:

--- a/src/OlStyler.js
+++ b/src/OlStyler.js
@@ -12,6 +12,14 @@ import getPolygonPointStyle from './styles/polygonPointStyle';
 const defaultStyles = [defaultPointStyle];
 
 /**
+ * Evaluation context for style functions.
+ * @typedef {object} EvaluationContext
+ * @property {Function} getProperty A function (feature, propertyName) -> value that returns the value of the property of a feature.
+ * @property {Function} getId A function feature -> any that gets the id of a feature.
+ * @property {number} resolution The current resolution in ground units in meters / pixel.
+ */
+
+/**
  * @private
  * Convert symbolizers together with the feature to OL style objects and append them to the OL styles array.
  * @example appendStyles(styles, point[j], feature, getPointStyle);
@@ -19,17 +27,11 @@ const defaultStyles = [defaultPointStyle];
  * @param {Array<object>} symbolizers Array of feature symbolizers.
  * @param {ol/feature} feature OpenLayers feature.
  * @param {Function} styleFunction Function for getting the OL style object. Signature (symbolizer, feature) => OL style.
- * @param {Function} getProperty A property getter: (feature, propertyName) => property value.
+ * @param {EvaluationContext} context Evaluation context.
  */
-function appendStyles(
-  styles,
-  symbolizers,
-  feature,
-  styleFunction,
-  getProperty
-) {
+function appendStyles(styles, symbolizers, feature, styleFunction, context) {
   (symbolizers || []).forEach(symbolizer => {
-    const olStyle = styleFunction(symbolizer, feature, getProperty);
+    const olStyle = styleFunction(symbolizer, feature, context);
     if (olStyle) {
       styles.push(olStyle);
     }
@@ -42,7 +44,7 @@ function appendStyles(
  * @param {object} categorizedSymbolizers Symbolizers categorized by type, e.g. .pointSymbolizers = [array of point symbolizer objects].
  * @param {object|Feature} feature {@link http://geojson.org|geojson}
  *  or {@link https://openlayers.org/en/latest/apidoc/module-ol_Feature-Feature.html|ol/Feature} Changed in 0.0.04 & 0.0.5!
- * @param {Function} getProperty A property getter: (feature, propertyName) => property value.
+ * @param {EvaluationContext} context Evaluation context.
  * @param {object} [options] Optional options object.
  * @param {boolean} [options.strictGeometryMatch] Default false. When true, only apply symbolizers to the corresponding geometry type.
  * E.g. point symbolizers will not be applied to lines and polygons. Default false (according to SLD spec).
@@ -52,7 +54,7 @@ function appendStyles(
 export default function OlStyler(
   categorizedSymbolizers,
   feature,
-  getProperty,
+  context,
   options = {}
 ) {
   const {
@@ -78,29 +80,23 @@ export default function OlStyler(
   switch (geometryType) {
     case 'Point':
     case 'MultiPoint':
-      appendStyles(
-        styles,
-        pointSymbolizers,
-        feature,
-        getPointStyle,
-        getProperty
-      );
-      appendStyles(styles, textSymbolizers, feature, getTextStyle, getProperty);
+      appendStyles(styles, pointSymbolizers, feature, getPointStyle, context);
+      appendStyles(styles, textSymbolizers, feature, getTextStyle, context);
       break;
 
     case 'LineString':
     case 'MultiLineString':
-      appendStyles(styles, lineSymbolizers, feature, getLineStyle, getProperty);
+      appendStyles(styles, lineSymbolizers, feature, getLineStyle, context);
       if (!styleOptions.strictGeometryMatch) {
         appendStyles(
           styles,
           pointSymbolizers,
           feature,
           getLinePointStyle,
-          getProperty
+          context
         );
       }
-      appendStyles(styles, textSymbolizers, feature, getTextStyle, getProperty);
+      appendStyles(styles, textSymbolizers, feature, getTextStyle, context);
       break;
 
     case 'Polygon':
@@ -110,25 +106,19 @@ export default function OlStyler(
         polygonSymbolizers,
         feature,
         getPolygonStyle,
-        getProperty
+        context
       );
       if (!styleOptions.strictGeometryMatch) {
-        appendStyles(
-          styles,
-          lineSymbolizers,
-          feature,
-          getLineStyle,
-          getProperty
-        );
+        appendStyles(styles, lineSymbolizers, feature, getLineStyle, context);
       }
       appendStyles(
         styles,
         pointSymbolizers,
         feature,
         getPolygonPointStyle,
-        getProperty
+        context
       );
-      appendStyles(styles, textSymbolizers, feature, getTextStyle, getProperty);
+      appendStyles(styles, textSymbolizers, feature, getTextStyle, context);
       break;
 
     default:
@@ -189,23 +179,27 @@ export function createOlStyleFunction(featureTypeStyle, options = {}) {
   // Keep track of whether a callback has been registered per image url.
   const callbackRef = {};
 
+  // Evaluation context.
+  const context = {};
+
+  context.getProperty =
+    typeof options.getProperty === 'function'
+      ? options.getProperty
+      : getOlFeatureProperty;
+
+  context.getId = getOlFeatureId;
+
   return (feature, mapResolution) => {
     // Determine resolution in meters/pixel.
-    const resolution =
+    const groundResolution =
       typeof options.convertResolution === 'function'
         ? options.convertResolution(mapResolution)
         : mapResolution;
 
-    const getProperty =
-      typeof options.getProperty === 'function'
-        ? options.getProperty
-        : getOlFeatureProperty;
+    context.resolution = groundResolution;
 
     // Determine applicable style rules for the feature, taking feature properties and current resolution into account.
-    const rules = getRules(featureTypeStyle, feature, resolution, {
-      getProperty,
-      getFeatureId: getOlFeatureId,
-    });
+    const rules = getRules(featureTypeStyle, feature, context);
 
     // Start loading images for external graphic symbolizers and when loaded:
     // * update symbolizers to use the cached image.
@@ -221,7 +215,7 @@ export function createOlStyleFunction(featureTypeStyle, options = {}) {
     const categorizedSymbolizers = categorizeSymbolizers(rules);
 
     // Determine style rule array.
-    const olStyles = OlStyler(categorizedSymbolizers, feature, getProperty);
+    const olStyles = OlStyler(categorizedSymbolizers, feature, context);
 
     return olStyles;
   };

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -59,21 +59,16 @@ export function getStyle(layer, name) {
  * getRules(style.featuretypestyles['0'], geojson, resolution);
  * @param  {FeatureTypeStyle} featureTypeStyle
  * @param  {object} feature geojson
- * @param  {number} resolution m/px
- * @param  {Function} options.getProperty An optional function with parameters (feature, propertyName)
- * that can be used to extract a property value from a feature.
- * When not given, properties are read from feature.properties directly.Error
- * @param  {Function} options.getFeatureId An optional function to extract the feature id from a feature.Error
- * When not given, feature id is read from feature.id.
+ * @param {EvaluationContext} context Evaluation context.
  * @return {Rule[]}
  */
-export function getRules(featureTypeStyle, feature, resolution, options = {}) {
+export function getRules(featureTypeStyle, feature, context) {
   const validRules = [];
   let elseFilterCount = 0;
   for (let j = 0; j < featureTypeStyle.rules.length; j += 1) {
     const rule = featureTypeStyle.rules[j];
     // Only keep rules that pass the rule's min/max scale denominator checks.
-    if (scaleSelector(rule, resolution)) {
+    if (scaleSelector(rule, context.resolution)) {
       if (rule.elsefilter) {
         // In the first rule selection step, keep all rules with an ElseFilter.
         validRules.push(rule);
@@ -81,7 +76,7 @@ export function getRules(featureTypeStyle, feature, resolution, options = {}) {
       } else if (!rule.filter) {
         // Rules without filter always apply.
         validRules.push(rule);
-      } else if (filterSelector(rule.filter, feature, options)) {
+      } else if (filterSelector(rule.filter, feature, context)) {
         // If a rule has a filter, only keep it if the feature passes the filter.
         validRules.push(rule);
       }

--- a/src/olEvaluator.js
+++ b/src/olEvaluator.js
@@ -37,14 +37,14 @@ export function isDynamicExpression(expression) {
  * Constant expressions are returned as-is.
  * @param {Expression} expression SLD object expression.
  * @param {ol/feature} feature OpenLayers feature instance.
- * @param {function} getProperty A function to get a specific property value from a feature.
+ * @param {EvaluationContext} context Evaluation context.
  * @param {any} defaultValue Optional default value to use when feature is null.
  * Signature (feature, propertyName) => property value.
  */
 export default function evaluate(
   expression,
   feature,
-  getProperty,
+  context,
   defaultValue = null
 ) {
   // Determine the value of the expression.
@@ -75,7 +75,7 @@ export default function evaluate(
       ) {
         value = feature.getGeometry();
       } else {
-        value = getProperty(feature, propertyName);
+        value = context.getProperty(feature, propertyName);
       }
     } else {
       value = defaultValue;
@@ -86,7 +86,7 @@ export default function evaluate(
       value = evaluate(
         expression.children[0],
         feature,
-        getProperty,
+        context,
         defaultValue
       );
     } else {
@@ -96,7 +96,7 @@ export default function evaluate(
         childValues.push(
           // Do not use default values when evaluating children. Only apply default is
           // the concatenated result is empty.
-          evaluate(expression.children[k], feature, getProperty, null)
+          evaluate(expression.children[k], feature, context, null)
         );
       }
       value = childValues.join('');
@@ -109,7 +109,7 @@ export default function evaluate(
       try {
         // evaluate parameter expressions.
         const paramValues = expression.params.map(paramExpression =>
-          evaluate(paramExpression, feature, getProperty)
+          evaluate(paramExpression, feature, context)
         );
         value = func(...paramValues);
       } catch (e) {

--- a/src/olEvaluator.js
+++ b/src/olEvaluator.js
@@ -130,7 +130,7 @@ export default function evaluate(
     value === '' ||
     Number.isNaN(value)
   ) {
-    return defaultValue;
+    value = defaultValue;
   }
 
   // Convert value to number if expression is flagged as numeric.

--- a/src/styles/dynamicStyles.js
+++ b/src/styles/dynamicStyles.js
@@ -8,21 +8,16 @@ import { getOLColorString } from './styleUtils';
  * @param {ol/style/Style} olStyle OL Style instance.
  * @param {object} symbolizer SLD symbolizer object.
  * @param {ol/Feature|GeoJSON} feature OL Feature instance or GeoJSON feature object.
- * @param {Function} getProperty Property getter (feature, propertyName) => propertyValue.
+ * @param {EvaluationContext} context Evaluation context.
  * @returns {bool} Returns true if any property-dependent fill style changes have been made.
  */
-export function applyDynamicFillStyling(
-  olStyle,
-  symbolizer,
-  feature,
-  getProperty
-) {
+export function applyDynamicFillStyling(olStyle, symbolizer, feature, context) {
   const olFill = olStyle.getFill();
   if (!olFill) {
     return false;
   }
 
-  if (typeof getProperty !== 'function') {
+  if (!context) {
     return false;
   }
 
@@ -36,13 +31,8 @@ export function applyDynamicFillStyling(
     isDynamicExpression(styling.fill) ||
     isDynamicExpression(styling.fillOpacity)
   ) {
-    const fillColor = evaluate(styling.fill, feature, getProperty, '#808080');
-    const fillOpacity = evaluate(
-      styling.fillOpacity,
-      feature,
-      getProperty,
-      1.0
-    );
+    const fillColor = evaluate(styling.fill, feature, context, '#808080');
+    const fillOpacity = evaluate(styling.fillOpacity, feature, context, 1.0);
     olFill.setColor(getOLColorString(fillColor, fillOpacity));
     somethingChanged = true;
   }
@@ -57,21 +47,21 @@ export function applyDynamicFillStyling(
  * @param {ol/style/Style} olStyle OL Style instance.
  * @param {object} symbolizer SLD symbolizer object.
  * @param {ol/Feature|GeoJSON} feature OL Feature instance or GeoJSON feature object.
- * @param {Function} getProperty Property getter (feature, propertyName) => propertyValue.
+ * @param {EvaluationContext} context Evaluation context.
  * @returns {bool} Returns true if any property-dependent stroke style changes have been made.
  */
 export function applyDynamicStrokeStyling(
   olStyle,
   symbolizer,
   feature,
-  getProperty
+  context
 ) {
   const olStroke = olStyle.getStroke();
   if (!olStroke) {
     return false;
   }
 
-  if (typeof getProperty !== 'function') {
+  if (!context) {
     return false;
   }
 
@@ -82,12 +72,7 @@ export function applyDynamicStrokeStyling(
 
   // Change stroke width if it's property based.
   if (isDynamicExpression(styling.strokeWidth)) {
-    const strokeWidth = evaluate(
-      styling.strokeWidth,
-      feature,
-      getProperty,
-      1.0
-    );
+    const strokeWidth = evaluate(styling.strokeWidth, feature, context, 1.0);
     olStroke.setWidth(strokeWidth);
     somethingChanged = true;
   }
@@ -97,16 +82,11 @@ export function applyDynamicStrokeStyling(
     isDynamicExpression(styling.stroke) ||
     isDynamicExpression(styling.strokeOpacity)
   ) {
-    const strokeColor = evaluate(
-      styling.stroke,
-      feature,
-      getProperty,
-      '#000000'
-    );
+    const strokeColor = evaluate(styling.stroke, feature, context, '#000000');
     const strokeOpacity = evaluate(
       styling.strokeOpacity,
       feature,
-      getProperty,
+      context,
       1.0
     );
     olStroke.setColor(getOLColorString(strokeColor, strokeOpacity));
@@ -123,21 +103,16 @@ export function applyDynamicStrokeStyling(
  * @param {ol/style/Style} olStyle OL Style instance.
  * @param {object} symbolizer SLD symbolizer object.
  * @param {ol/Feature|GeoJSON} feature OL Feature instance or GeoJSON feature object.
- * @param {Function} getProperty Property getter (feature, propertyName) => propertyValue.
+ * @param {EvaluationContext} context Evaluation context.
  * @returns {bool} Returns true if any property-dependent stroke style changes have been made.
  */
-export function applyDynamicTextStyling(
-  olStyle,
-  symbolizer,
-  feature,
-  getProperty
-) {
+export function applyDynamicTextStyling(olStyle, symbolizer, feature, context) {
   const olText = olStyle.getText();
   if (!olText) {
     return false;
   }
 
-  if (typeof getProperty !== 'function') {
+  if (!context) {
     return false;
   }
 
@@ -156,12 +131,7 @@ export function applyDynamicTextStyling(
         },
       },
     };
-    applyDynamicStrokeStyling(
-      olText,
-      textStrokeSymbolizer,
-      feature,
-      getProperty
-    );
+    applyDynamicStrokeStyling(olText, textStrokeSymbolizer, feature, context);
   }
 
   // Halo fill has to be applied as olText fill.
@@ -172,17 +142,12 @@ export function applyDynamicTextStyling(
     (isDynamicExpression(symbolizer.halo.fill.styling.fill) ||
       isDynamicExpression(symbolizer.halo.fill.styling.fillOpacity))
   ) {
-    applyDynamicFillStyling(olText, symbolizer.halo, feature, getProperty);
+    applyDynamicFillStyling(olText, symbolizer.halo, feature, context);
   }
 
   // Halo radius has to be applied as olText.stroke width.
   if (symbolizer.halo && isDynamicExpression(symbolizer.halo.radius)) {
-    const haloRadius = evaluate(
-      symbolizer.halo.radius,
-      feature,
-      getProperty,
-      1.0
-    );
+    const haloRadius = evaluate(symbolizer.halo.radius, feature, context, 1.0);
     const olStroke = olText.getStroke();
     if (olStroke) {
       const haloStrokeWidth =

--- a/src/styles/graphicStrokeStyle.js
+++ b/src/styles/graphicStrokeStyle.js
@@ -117,10 +117,9 @@ function renderStrokeMarks(
  * to be used inside an OpenLayers Style.renderer function.
  * @private
  * @param {LineSymbolizer} linesymbolizer SLD line symbolizer object.
- * @param {Function} getProperty A property getter: (feature, propertyName) => property value.
  * @returns {ol/style/Style~RenderFunction} A style renderer function (pixelCoords, renderState) => void.
  */
-export function getGraphicStrokeRenderer(linesymbolizer, getProperty) {
+export function getGraphicStrokeRenderer(linesymbolizer) {
   if (!(linesymbolizer.stroke && linesymbolizer.stroke.graphicstroke)) {
     throw new Error(
       'getGraphicStrokeRenderer error: symbolizer.stroke.graphicstroke null or undefined.'
@@ -163,7 +162,7 @@ export function getGraphicStrokeRenderer(linesymbolizer, getProperty) {
     const pointStyle = getPointStyle(
       graphicstroke,
       renderState.feature,
-      getProperty
+      null
     );
 
     // Calculate graphic spacing.
@@ -176,7 +175,7 @@ export function getGraphicStrokeRenderer(linesymbolizer, getProperty) {
       evaluate(
         graphicSizeExpression,
         renderState.feature,
-        getProperty,
+        null,
         defaultGraphicSize
       )
     );
@@ -199,10 +198,9 @@ export function getGraphicStrokeRenderer(linesymbolizer, getProperty) {
  * Create an OpenLayers style for rendering line symbolizers with a GraphicStroke.
  * @private
  * @param {LineSymbolizer} linesymbolizer SLD line symbolizer object.
- * @param {Function} getProperty A property getter: (feature, propertyName) => property value.
  * @returns {ol/style/Style} An OpenLayers style instance.
  */
-function getGraphicStrokeStyle(linesymbolizer, getProperty) {
+function getGraphicStrokeStyle(linesymbolizer) {
   if (!(linesymbolizer.stroke && linesymbolizer.stroke.graphicstroke)) {
     throw new Error(
       'getGraphicStrokeStyle error: linesymbolizer.stroke.graphicstroke null or undefined.'
@@ -210,7 +208,7 @@ function getGraphicStrokeStyle(linesymbolizer, getProperty) {
   }
 
   return new Style({
-    renderer: getGraphicStrokeRenderer(linesymbolizer, getProperty),
+    renderer: getGraphicStrokeRenderer(linesymbolizer),
   });
 }
 

--- a/src/styles/linePointStyle.js
+++ b/src/styles/linePointStyle.js
@@ -9,9 +9,10 @@ import { getLineMidpoint } from './geometryCalcs';
  * The style will render a point on the middle of the line.
  * @param {object} symbolizer SLD symbolizer object.
  * @param {ol/Feature} feature OpenLayers Feature.
+ * @param {EvaluationContext} context Evaluation context.
  * @returns {ol/Style} OpenLayers style instance.
  */
-function getLinePointStyle(symbolizer, feature) {
+function getLinePointStyle(symbolizer, feature, context) {
   if (typeof feature.getGeometry !== 'function') {
     return null;
   }
@@ -24,12 +25,12 @@ function getLinePointStyle(symbolizer, feature) {
   let pointStyle = null;
   const geomType = geom.getType();
   if (geomType === 'LineString') {
-    pointStyle = getPointStyle(symbolizer, feature);
+    pointStyle = getPointStyle(symbolizer, feature, context);
     pointStyle.setGeometry(new Point(getLineMidpoint(geom)));
   } else if (geomType === 'MultiLineString') {
     const lineStrings = geom.getLineStrings();
     const multiPointCoords = lineStrings.map(getLineMidpoint);
-    pointStyle = getPointStyle(symbolizer, feature);
+    pointStyle = getPointStyle(symbolizer, feature, context);
     pointStyle.setGeometry(new MultiPoint(multiPointCoords));
   }
 

--- a/src/styles/lineStyle.js
+++ b/src/styles/lineStyle.js
@@ -26,13 +26,15 @@ const cachedLineStyle = memoizeStyleFunction(lineStyle);
  * @private
  * Get an OL line style instance for a feature according to a symbolizer.
  * @param {object} symbolizer SLD symbolizer object.
+ * @param {ol/Feature} feature OpenLayers Feature.
+ * @param {EvaluationContext} context Evaluation context.
  * @returns {ol/Style} OpenLayers style instance.
  */
-function getLineStyle(symbolizer, feature, getProperty) {
+function getLineStyle(symbolizer, feature, context) {
   const olStyle = cachedLineStyle(symbolizer);
 
   // Apply dynamic properties.
-  applyDynamicStrokeStyling(olStyle, symbolizer, feature, getProperty);
+  applyDynamicStrokeStyling(olStyle, symbolizer, feature, context);
 
   return olStyle;
 }

--- a/src/styles/pointStyle.js
+++ b/src/styles/pointStyle.js
@@ -102,10 +102,10 @@ const cachedPointStyle = memoizeStyleFunction(pointStyle);
  * Get an OL point style instance for a feature according to a symbolizer.
  * @param {object} symbolizer SLD symbolizer object.
  * @param {ol/Feature} feature OpenLayers Feature.
- * @param {Function} getProperty A property getter: (feature, propertyName) => property value.
+ * @param {EvaluationContext} context Evaluation context.
  * @returns {ol/Style} OpenLayers style instance.
  */
-function getPointStyle(symbolizer, feature, getProperty) {
+function getPointStyle(symbolizer, feature, context) {
   // According to SLD spec, when a point symbolizer has no Graphic, nothing will be rendered.
   if (!(symbolizer && symbolizer.graphic)) {
     return emptyStyle;
@@ -125,9 +125,8 @@ function getPointStyle(symbolizer, feature, getProperty) {
   // Calculate size and rotation values first.
   const { size, rotation } = graphic;
   const sizeValue =
-    Number(evaluate(size, feature, getProperty)) || DEFAULT_MARK_SIZE;
-  const rotationDegrees =
-    Number(evaluate(rotation, feature, getProperty)) || 0.0;
+    Number(evaluate(size, feature, context)) || DEFAULT_MARK_SIZE;
+  const rotationDegrees = Number(evaluate(rotation, feature, context)) || 0.0;
 
   // --- Update dynamic size ---
   if (isDynamicExpression(size)) {
@@ -165,14 +164,14 @@ function getPointStyle(symbolizer, feature, getProperty) {
       olImage,
       graphic.mark,
       feature,
-      getProperty
+      context
     );
 
     const fillChanged = applyDynamicFillStyling(
       olImage,
       graphic.mark,
       feature,
-      getProperty
+      context
     );
 
     if (strokeChanged || fillChanged) {
@@ -196,8 +195,8 @@ function getPointStyle(symbolizer, feature, getProperty) {
       typeof displacementx !== 'undefined' ||
       typeof displacementy !== 'undefined'
     ) {
-      const dx = evaluate(displacementx, feature, getProperty) || 0.0;
-      const dy = evaluate(displacementy, feature, getProperty) || 0.0;
+      const dx = evaluate(displacementx, feature, context) || 0.0;
+      const dy = evaluate(displacementy, feature, context) || 0.0;
       if (dx !== 0.0 || dy !== 0.0) {
         olImage.setDisplacement([dx, dy]);
       }

--- a/src/styles/polygonPointStyle.js
+++ b/src/styles/polygonPointStyle.js
@@ -20,9 +20,10 @@ function getInteriorPoint(geometry) {
  * The style will render a point on the middle of the line.
  * @param {object} symbolizer SLD symbolizer object.
  * @param {ol/Feature} feature OpenLayers Feature.
+ * @param {EvaluationContext} context Evaluation context.
  * @returns {ol/Style} OpenLayers style instance.
  */
-function getPolygonPointStyle(symbolizer, feature) {
+function getPolygonPointStyle(symbolizer, feature, context) {
   if (typeof feature.getGeometry !== 'function') {
     return null;
   }
@@ -35,12 +36,12 @@ function getPolygonPointStyle(symbolizer, feature) {
   let pointStyle = null;
   const geomType = geom.getType();
   if (geomType === 'Polygon') {
-    pointStyle = getPointStyle(symbolizer, feature);
+    pointStyle = getPointStyle(symbolizer, feature, context);
     pointStyle.setGeometry(new Point(getInteriorPoint(geom)));
   } else if (geomType === 'MultiPolygon') {
     const polygons = geom.getPolygons();
     const multiPointCoords = polygons.map(getInteriorPoint);
-    pointStyle = getPointStyle(symbolizer, feature);
+    pointStyle = getPointStyle(symbolizer, feature, context);
     pointStyle.setGeometry(new MultiPoint(multiPointCoords));
   }
 

--- a/src/styles/polygonStyle.js
+++ b/src/styles/polygonStyle.js
@@ -14,7 +14,10 @@ import { memoizeStyleFunction } from './styleUtils';
 import { getCachedImage, getImageLoadingState } from '../imageCache';
 import { imageLoadingPolygonStyle, imageErrorPolygonStyle } from './static';
 import { getSimpleStroke, getSimpleFill } from './simpleStyles';
-import { applyDynamicFillStyling, applyDynamicStrokeStyling } from './dynamicStyles';
+import {
+  applyDynamicFillStyling,
+  applyDynamicStrokeStyling,
+} from './dynamicStyles';
 import { getGraphicStrokeRenderer } from './graphicStrokeStyle';
 import getPointStyle from './pointStyle';
 import getQGISBrushFill from './qgisBrushFill';
@@ -288,14 +291,16 @@ const cachedPolygonStyle = memoizeStyleFunction(polygonStyle);
  * @private
  * Get an OL line style instance for a feature according to a symbolizer.
  * @param {object} symbolizer SLD symbolizer object.
+ * @param {ol/Feature} feature OpenLayers Feature.
+ * @param {EvaluationContext} context Evaluation context.
  * @returns {ol/Style} OpenLayers style instance.
  */
-function getPolygonStyle(symbolizer, feature, getProperty) {
+function getPolygonStyle(symbolizer, feature, context) {
   const olStyle = cachedPolygonStyle(symbolizer);
 
   // Apply dynamic properties.
-  applyDynamicFillStyling(olStyle, symbolizer, feature, getProperty);
-  applyDynamicStrokeStyling(olStyle, symbolizer, feature, getProperty);
+  applyDynamicFillStyling(olStyle, symbolizer, feature, context);
+  applyDynamicStrokeStyling(olStyle, symbolizer, feature, context);
 
   return olStyle;
 }

--- a/src/styles/textStyle.js
+++ b/src/styles/textStyle.js
@@ -120,10 +120,10 @@ const cachedTextStyle = memoizeStyleFunction(textStyle);
  * Get an OL text style instance for a feature according to a symbolizer.
  * @param {object} symbolizer SLD symbolizer object.
  * @param {ol/Feature} feature OpenLayers Feature.
- * @param {Function} getProperty A property getter: (feature, propertyName) => property value.
+ * @param {EvaluationContext} context Evaluation context.
  * @returns {ol/Style} OpenLayers style instance.
  */
-function getTextStyle(symbolizer, feature, getProperty) {
+function getTextStyle(symbolizer, feature, context) {
   const olStyle = cachedTextStyle(symbolizer);
   const olText = olStyle.getText();
   if (!olText) {
@@ -135,7 +135,7 @@ function getTextStyle(symbolizer, feature, getProperty) {
 
   // Set text only if the label expression is dynamic.
   if (isDynamicExpression(label)) {
-    const labelText = evaluate(label, feature, getProperty, '');
+    const labelText = evaluate(label, feature, context, '');
     // Important! OpenLayers expects the text property to always be a string.
     olText.setText(labelText.toString());
   }
@@ -150,7 +150,7 @@ function getTextStyle(symbolizer, feature, getProperty) {
       const labelRotationDegrees = evaluate(
         pointPlacementRotation,
         feature,
-        getProperty,
+        context,
         0.0
       );
       olText.setRotation((Math.PI * labelRotationDegrees) / 180.0); // OL rotation is in radians.
@@ -173,7 +173,7 @@ function getTextStyle(symbolizer, feature, getProperty) {
   olText.setPlacement(placement);
 
   // Apply dynamic style properties.
-  applyDynamicTextStyling(olStyle, symbolizer, feature, getProperty);
+  applyDynamicTextStyling(olStyle, symbolizer, feature, context);
 
   // Adjust font if one or more font svgparameters are dynamic.
   if (symbolizer.font && symbolizer.font.styling) {
@@ -187,22 +187,12 @@ function getTextStyle(symbolizer, feature, getProperty) {
       const fontFamily = evaluate(
         fontStyling.fontFamily,
         feature,
-        getProperty,
+        context,
         'sans-serif'
       );
-      const fontStyle = evaluate(
-        fontStyling.fontStyle,
-        feature,
-        getProperty,
-        ''
-      );
-      const fontWeight = evaluate(
-        fontStyling.fontWeight,
-        feature,
-        getProperty,
-        ''
-      );
-      const fontSize = evaluate(fontStyling.fontSize, feature, getProperty, 10);
+      const fontStyle = evaluate(fontStyling.fontStyle, feature, context, '');
+      const fontWeight = evaluate(fontStyling.fontWeight, feature, context, '');
+      const fontSize = evaluate(fontStyling.fontSize, feature, context, 10);
       const olFontString = `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`;
       olText.setFont(olFontString);
     }

--- a/test/Filter.test.js
+++ b/test/Filter.test.js
@@ -8,6 +8,12 @@ import addBuiltInFunctions from '../src/functions/builtins';
 
 const fmtGeoJSON = new OLFormatGeoJSON();
 
+const context = {
+  getProperty: (feature, propertyName) => feature.properties[propertyName],
+  getId: feature => feature.id,
+  resolution: 10,
+};
+
 describe('filter rules', () => {
   describe('FID filter', () => {
     const filterXml = `<StyledLayerDescriptor xmlns="http://www.opengis.net/ogc"><Filter>
@@ -18,12 +24,12 @@ describe('filter rules', () => {
 
     it('filter fid', () => {
       const feature = { id: 'tasmania_water_bodies.2' };
-      expect(filterSelector(filter, feature)).to.be.true;
+      expect(filterSelector(filter, feature, context)).to.be.true;
     });
 
     it('filter fid false', () => {
       const feature = { id: 'tasmania_water_bodies.0' };
-      expect(filterSelector(filter, feature)).to.be.false;
+      expect(filterSelector(filter, feature, context)).to.be.false;
     });
   });
 
@@ -37,7 +43,7 @@ describe('filter rules', () => {
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
       const feature = { properties: { AREA: 1065512598 } };
-      expect(filterSelector(filter, feature)).to.be.true;
+      expect(filterSelector(filter, feature, context)).to.be.true;
     });
 
     it('propertyislessthan when false', () => {
@@ -49,7 +55,7 @@ describe('filter rules', () => {
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
       const feature = { properties: { AREA: 1065512599 } };
-      expect(filterSelector(filter, feature)).to.be.false;
+      expect(filterSelector(filter, feature, context)).to.be.false;
     });
 
     it('propertyisequalto', () => {
@@ -61,7 +67,7 @@ describe('filter rules', () => {
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
       const feature = { properties: { PERIMETER: 1071304933 } };
-      expect(filterSelector(filter, feature)).to.be.true;
+      expect(filterSelector(filter, feature, context)).to.be.true;
     });
 
     it('propertyisequalto for non existent prop', () => {
@@ -73,7 +79,7 @@ describe('filter rules', () => {
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
       const feature = { properties: { PERIMETEEER: 1071304933 } };
-      expect(filterSelector(filter, feature)).to.be.false;
+      expect(filterSelector(filter, feature, context)).to.be.false;
     });
 
     it('propertyisnotequalto', () => {
@@ -85,9 +91,9 @@ describe('filter rules', () => {
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
       const featureeq = { properties: { PERIMETER: 1071304933 } };
-      expect(filterSelector(filter, featureeq)).to.be.false;
+      expect(filterSelector(filter, featureeq, context)).to.be.false;
       const featureuneq = { properties: { PERIMETER: 1071304900 } };
-      expect(filterSelector(filter, featureuneq)).to.be.true;
+      expect(filterSelector(filter, featureuneq, context)).to.be.true;
     });
 
     it('propertyisnull', () => {
@@ -98,9 +104,9 @@ describe('filter rules', () => {
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
       const featureeq = { properties: { PERIMETER: 1071304933 } };
-      expect(filterSelector(filter, featureeq)).to.be.false;
+      expect(filterSelector(filter, featureeq, context)).to.be.false;
       const featureuneq = { properties: { PERIMETER: null } };
-      expect(filterSelector(filter, featureuneq)).to.be.true;
+      expect(filterSelector(filter, featureuneq, context)).to.be.true;
     });
 
     it('propertyislessthanorequalto', () => {
@@ -112,11 +118,11 @@ describe('filter rules', () => {
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
       const feature = { properties: { PERIMETER: 1071304933 } };
-      expect(filterSelector(filter, feature)).to.be.true;
+      expect(filterSelector(filter, feature, context)).to.be.true;
       const featurels = { properties: { PERIMETER: 1071304932 } };
-      expect(filterSelector(filter, featurels)).to.be.true;
+      expect(filterSelector(filter, featurels, context)).to.be.true;
       const featuregt = { properties: { PERIMETER: 1071304934 } };
-      expect(filterSelector(filter, featuregt)).to.be.false;
+      expect(filterSelector(filter, featuregt, context)).to.be.false;
     });
 
     it('propertyisgreaterthan', () => {
@@ -128,7 +134,7 @@ describe('filter rules', () => {
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
       const feature = { properties: { PERIMETER: 1071304933 } };
-      expect(filterSelector(filter, feature)).to.be.false;
+      expect(filterSelector(filter, feature, context)).to.be.false;
     });
 
     it('propertyisgreaterthanorequalto', () => {
@@ -140,7 +146,7 @@ describe('filter rules', () => {
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
       const feature = { properties: { PERIMETER: 1071304933 } };
-      expect(filterSelector(filter, feature)).to.be.true;
+      expect(filterSelector(filter, feature, context)).to.be.true;
     });
 
     describe('propertyisbetween', () => {
@@ -163,27 +169,27 @@ describe('filter rules', () => {
 
       it('inside', () => {
         const feature = { properties: { age: 42 } };
-        expect(filterSelector(filter, feature)).to.be.true;
+        expect(filterSelector(filter, feature, context)).to.be.true;
       });
 
       it('at lower bound', () => {
         const feature = { properties: { age: 30 } };
-        expect(filterSelector(filter, feature)).to.be.true;
+        expect(filterSelector(filter, feature, context)).to.be.true;
       });
 
       it('below lower bound', () => {
         const feature = { properties: { age: 10 } };
-        expect(filterSelector(filter, feature)).to.be.false;
+        expect(filterSelector(filter, feature, context)).to.be.false;
       });
 
       it('at upper bound', () => {
         const feature = { properties: { age: 100 } };
-        expect(filterSelector(filter, feature)).to.be.true;
+        expect(filterSelector(filter, feature, context)).to.be.true;
       });
 
       it('above upper bound', () => {
         const feature = { properties: { age: 100.001 } };
-        expect(filterSelector(filter, feature)).to.be.false;
+        expect(filterSelector(filter, feature, context)).to.be.false;
       });
     });
 
@@ -202,7 +208,7 @@ describe('filter rules', () => {
       function testLike(pattern, value) {
         const filter = Object.assign(filterBase, { expression2: pattern });
         const feature = { properties: { value } };
-        return filterSelector(filter, feature);
+        return filterSelector(filter, feature, context);
       }
 
       it('exact match true', () => {
@@ -242,7 +248,7 @@ describe('filter rules', () => {
         </Filter></StyledLayerDescriptor>`;
         const { filter } = Reader(filterXml);
         const feature = { properties: { text: 'TEST' } };
-        expect(filterSelector(filter, feature)).to.be.true;
+        expect(filterSelector(filter, feature, context)).to.be.true;
       });
     });
 
@@ -269,7 +275,7 @@ describe('filter rules', () => {
             matchcase: true,
           };
           const dummyFeature = { properties: {} };
-          expect(filterSelector(filter, dummyFeature)).to.be.true;
+          expect(filterSelector(filter, dummyFeature, context)).to.be.true;
         });
       });
     });
@@ -285,7 +291,7 @@ describe('filter rules', () => {
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
       const emptyFeature = { properties: { text: null } };
-      expect(filterSelector(filter, emptyFeature)).to.be.false;
+      expect(filterSelector(filter, emptyFeature, context)).to.be.false;
     });
 
     it('propertyisbetween should return false for missing/null values', () => {
@@ -303,7 +309,7 @@ describe('filter rules', () => {
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
       const emptyFeature = { properties: { age: null } };
-      expect(filterSelector(filter, emptyFeature)).to.be.false;
+      expect(filterSelector(filter, emptyFeature, context)).to.be.false;
     });
 
     const operators = [
@@ -325,7 +331,7 @@ describe('filter rules', () => {
         </Filter></StyledLayerDescriptor>`;
         const { filter } = Reader(filterXml);
         const emptyFeature = { properties: { TEMPERATURE: null } };
-        expect(filterSelector(filter, emptyFeature)).to.be.false;
+        expect(filterSelector(filter, emptyFeature, context)).to.be.false;
       });
     });
   });
@@ -340,7 +346,7 @@ describe('filter rules', () => {
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
       const feature = { properties: { text: 'test' } };
-      expect(filterSelector(filter, feature)).to.be.true;
+      expect(filterSelector(filter, feature, context)).to.be.true;
     });
 
     it('propertyisgreaterthan with matchCase: true', () => {
@@ -352,7 +358,7 @@ describe('filter rules', () => {
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
       const feature = { properties: { text: 'monkey' } };
-      expect(filterSelector(filter, feature)).to.be.true;
+      expect(filterSelector(filter, feature, context)).to.be.true;
     });
 
     describe('propertyisbetween for strings', () => {
@@ -375,32 +381,32 @@ describe('filter rules', () => {
 
       it('inside', () => {
         const feature = { properties: { date: '1999-12-31' } };
-        expect(filterSelector(filter, feature)).to.be.true;
+        expect(filterSelector(filter, feature, context)).to.be.true;
       });
 
       it('at lower bound', () => {
         const feature = { properties: { date: '1980-05-02' } };
-        expect(filterSelector(filter, feature)).to.be.true;
+        expect(filterSelector(filter, feature, context)).to.be.true;
       });
 
       it('below lower bound', () => {
         const feature = { properties: { date: '1950-09-07' } };
-        expect(filterSelector(filter, feature)).to.be.false;
+        expect(filterSelector(filter, feature, context)).to.be.false;
       });
 
       it('at upper bound', () => {
         const feature = { properties: { date: '2021-06-27' } };
-        expect(filterSelector(filter, feature)).to.be.true;
+        expect(filterSelector(filter, feature, context)).to.be.true;
       });
 
       it('at upper bound, simple date', () => {
         const feature = { properties: { date: '2021-06-27' } };
-        expect(filterSelector(filter, feature)).to.be.true;
+        expect(filterSelector(filter, feature, context)).to.be.true;
       });
 
       it('above upper bound', () => {
         const feature = { properties: { date: '2222-12-21' } };
-        expect(filterSelector(filter, feature)).to.be.false;
+        expect(filterSelector(filter, feature, context)).to.be.false;
       });
     });
   });
@@ -445,7 +451,7 @@ describe('filter rules', () => {
           type: 'and',
           predicates: [lakeFilter, areaFilter2],
         };
-        expect(filterSelector(filter, feature)).to.be.true;
+        expect(filterSelector(filter, feature, context)).to.be.true;
       });
 
       it('and filter with 2 child filters of same type', () => {
@@ -453,7 +459,7 @@ describe('filter rules', () => {
           type: 'and',
           predicates: [areaFilter],
         };
-        expect(filterSelector(filter, feature)).to.be.true;
+        expect(filterSelector(filter, feature, context)).to.be.true;
       });
 
       it('and filter with no predicates returns false', () => {
@@ -461,7 +467,7 @@ describe('filter rules', () => {
           type: 'and',
           predicates: [],
         };
-        expect(filterSelector(filter, feature)).to.be.false;
+        expect(filterSelector(filter, feature, context)).to.be.false;
       });
     });
 
@@ -485,7 +491,7 @@ describe('filter rules', () => {
 
       it('or filter without predicates should return false', () => {
         const filter = { type: 'or', predicates: [] };
-        expect(filterSelector(filter, duckling)).to.be.false;
+        expect(filterSelector(filter, duckling, context)).to.be.false;
       });
 
       it('or filter with one match returns true', () => {
@@ -493,7 +499,7 @@ describe('filter rules', () => {
           type: 'or',
           predicates: [kwikFilter, kwekFilter, kwakFilter],
         };
-        expect(filterSelector(filter, duckling)).to.be.true;
+        expect(filterSelector(filter, duckling, context)).to.be.true;
       });
 
       it('or filter with no matches returns false', () => {
@@ -501,7 +507,7 @@ describe('filter rules', () => {
           type: 'or',
           predicates: [kwikFilter, kwekFilter],
         };
-        expect(filterSelector(filter, duckling)).to.be.false;
+        expect(filterSelector(filter, duckling, context)).to.be.false;
       });
     });
 
@@ -516,7 +522,7 @@ describe('filter rules', () => {
           </Not>
         </Filter></StyledLayerDescriptor>`;
         const { filter } = Reader(filterXml);
-        expect(filterSelector(filter, feature)).to.be.true;
+        expect(filterSelector(filter, feature, context)).to.be.true;
       });
     });
 
@@ -533,7 +539,7 @@ describe('filter rules', () => {
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
       const piet = { properties: { name: 'Piet' } };
-      expect(filterSelector(filter, piet)).to.be.true;
+      expect(filterSelector(filter, piet, context)).to.be.true;
     });
 
     it('Nested logical filters', () => {
@@ -559,9 +565,9 @@ describe('filter rules', () => {
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
       const sjenkie = { properties: { name: 'Sjenkie', age: 8 } };
-      expect(filterSelector(filter, sjenkie)).to.be.true;
+      expect(filterSelector(filter, sjenkie, context)).to.be.true;
       const piet = { properties: { name: 'Piet', age: 8 } };
-      expect(filterSelector(filter, piet)).to.be.false;
+      expect(filterSelector(filter, piet, context)).to.be.false;
     });
   });
 });
@@ -588,7 +594,7 @@ describe('Custom Feature Id extraction', () => {
     };
 
     const result = filterSelector(fidFilter, myFeature, {
-      getFeatureId: feature => feature.ogc_fid,
+      getId: feature => feature.ogc_fid,
     });
 
     expect(result).to.be.true;
@@ -611,10 +617,13 @@ describe('Custom property extraction', () => {
       }),
     };
 
-    const result = filterSelector(filter, myFeature, {
+    const customContext = {
+      ...context,
       getProperty: (feature, propertyName) =>
         feature.getAttributes()[propertyName],
-    });
+    };
+
+    const result = filterSelector(filter, myFeature, customContext);
 
     expect(result).to.be.false;
   });
@@ -641,10 +650,13 @@ describe('Custom property extraction', () => {
       }),
     };
 
-    const result = filterSelector(filter, myFeature, {
+    const customContext = {
+      ...context,
       getProperty: (feature, propertyName) =>
         feature.getAttributes()[propertyName],
-    });
+    };
+
+    const result = filterSelector(filter, myFeature, customContext);
 
     expect(result).to.be.true;
   });
@@ -659,7 +671,7 @@ describe('Custom property extraction', () => {
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
       const feature = { properties: {} };
-      const result = filterSelector(filter, feature);
+      const result = filterSelector(filter, feature, context);
       expect(result).to.be.true;
     });
 
@@ -672,7 +684,7 @@ describe('Custom property extraction', () => {
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
       const feature = { properties: { prop1: 42, prop2: 42 } };
-      const result = filterSelector(filter, feature);
+      const result = filterSelector(filter, feature, context);
       expect(result).to.be.true;
     });
   });
@@ -699,7 +711,7 @@ describe('Custom property extraction', () => {
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
       const feature = { properties: { title: 'Nieuwland' } };
-      const result = filterSelector(filter, feature);
+      const result = filterSelector(filter, feature, context);
       expect(result).to.be.true;
     });
 
@@ -725,7 +737,7 @@ describe('Custom property extraction', () => {
         </PropertyIsEqualTo>
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
-      const result = filterSelector(filter, lineFeature);
+      const result = filterSelector(filter, lineFeature, context);
       expect(result).to.be.true;
     });
 
@@ -758,7 +770,7 @@ describe('Custom property extraction', () => {
         </PropertyIsEqualTo>
       </Filter></StyledLayerDescriptor>`;
       const { filter } = Reader(filterXml);
-      const result = filterSelector(filter, lineFeature);
+      const result = filterSelector(filter, lineFeature, context);
       expect(result).to.be.true;
     });
   });

--- a/test/Utils.test.js
+++ b/test/Utils.test.js
@@ -127,11 +127,9 @@ describe('reads info from StyledLayerDescriptor object', () => {
           },
         ],
       };
-      const filteredRules = Utils.getRules(
-        featureTypeStyle,
-        testFeature,
-        0.28 // scale 1:1000.
-      );
+      const filteredRules = Utils.getRules(featureTypeStyle, testFeature, {
+        resolution: 0.28, // scale 1:1000.
+      });
       expect(filteredRules.map(rule => rule.name)).to.deep.equal(['rule2']);
     });
 


### PR DESCRIPTION
Replace getProperty in function signatures with context object containing
* A `getProperty(feature, propertyName)` function.
* A `getId(feature)` function.
* A `resolution` property with current resolution in ground units in metres / pixel.
