### PR TITLE
Handle renderfeature

### DIFF
--- a/docs/assets/sld-vector-tile.xml
+++ b/docs/assets/sld-vector-tile.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd"
+  xmlns:se="http://www.opengis.net/se">
+  <NamedLayer>
+    <UserStyle>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <ogc:Filter>
+            <ogc:PropertyIsEqualTo>
+              <ogc:Function name="dimension">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+              <ogc:Literal>0</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke>
+                  <se:SvgParameter name="stroke">#880000</se:SvgParameter>
+                  <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+                </se:Stroke>
+              </se:Mark>
+              <se:Size>6</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <ogc:Filter>
+            <ogc:PropertyIsEqualTo>
+              <ogc:Function name="dimension">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+              <ogc:Literal>1</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <se:LineSymbolizer>
+            <se:Stroke>
+              <se:SvgParameter name="stroke">#00AA00</se:SvgParameter>
+              <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+            </se:Stroke>
+          </se:LineSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <ogc:Filter>
+            <ogc:PropertyIsEqualTo>
+              <ogc:Function name="dimension">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+              <ogc:Literal>2</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <se:PolygonSymbolizer>
+            <se:Fill>
+              <se:SvgParameter name="fill">#FFFF00</se:SvgParameter>
+            </se:Fill>
+            <se:Stroke>
+              <se:SvgParameter name="stroke">#AA8800</se:SvgParameter>
+              <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+            </se:Stroke>
+          </se:PolygonSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/docs/assets/sld-vector-tile.xml
+++ b/docs/assets/sld-vector-tile.xml
@@ -59,11 +59,11 @@
           </ogc:Filter>
           <se:PolygonSymbolizer>
             <se:Fill>
-              <se:SvgParameter name="fill">#FFFF00</se:SvgParameter>
+              <se:SvgParameter name="fill">#EEEEFF</se:SvgParameter>
             </se:Fill>
             <se:Stroke>
-              <se:SvgParameter name="stroke">#AA8800</se:SvgParameter>
-              <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+              <se:SvgParameter name="stroke">#8888FF</se:SvgParameter>
+              <se:SvgParameter name="stroke-width">1</se:SvgParameter>
             </se:Stroke>
           </se:PolygonSymbolizer>
         </se:Rule>

--- a/docs/assets/sldreader-standalone.js
+++ b/docs/assets/sldreader-standalone.js
@@ -1,4 +1,4 @@
-/* Version: 0.6.0 - May 14, 2025 09:35:39 */
+/* Version: 0.6.0 - May 14, 2025 09:47:02 */
 var SLDReader = (function (exports, Style, Icon, Fill, Stroke, Circle, RegularShape, render, Point, LineString, extent, has, Polygon, MultiPolygon, Text, RenderFeature, MultiPoint) {
   'use strict';
 
@@ -1068,7 +1068,6 @@ var SLDReader = (function (exports, Style, Icon, Fill, Stroke, Circle, RegularSh
         value = childValues.join('');
       }
     } else if (expression.type === 'function') {
-      //TODO: shortcut maken als function 'dimension' heet en feature een RenderFeature is.
       const func = getFunction(expression.name);
       if (!func) {
         value = expression.fallbackValue;
@@ -3664,7 +3663,7 @@ var SLDReader = (function (exports, Style, Icon, Fill, Stroke, Circle, RegularSh
    * Get the dimension of a geometry. Multipart geometries will return the dimension of their separate parts.
    * @private
    * @param {ol/geom/x} olGeometry OpenLayers Geometry instance.
-   * @returns {number} The dimension of the geometry. Will return 0 for GeometryCollection or unknown type.
+   * @returns {number} The dimension of the geometry. Will return -1 for GeometryCollection or unknown type.
    */
   function dimension(olGeometry) {
     switch (geometryType(olGeometry)) {
@@ -3680,7 +3679,7 @@ var SLDReader = (function (exports, Style, Icon, Fill, Stroke, Circle, RegularSh
       case 'MultiPolygon':
         return 2;
       default:
-        return 0;
+        return -1;
     }
   }
 

--- a/docs/assets/sldreader-standalone.js
+++ b/docs/assets/sldreader-standalone.js
@@ -1,5 +1,5 @@
-/* Version: 0.6.0 - April 25, 2025 14:46:24 */
-var SLDReader = (function (exports, Style, Icon, Fill, Stroke, Circle, RegularShape, render, Point, LineString, extent, has, Polygon, MultiPolygon, Text, MultiPoint) {
+/* Version: 0.6.0 - May 14, 2025 09:35:39 */
+var SLDReader = (function (exports, Style, Icon, Fill, Stroke, Circle, RegularShape, render, Point, LineString, extent, has, Polygon, MultiPolygon, Text, RenderFeature, MultiPoint) {
   'use strict';
 
   const IMAGE_LOADING = 'IMAGE_LOADING';
@@ -1068,6 +1068,7 @@ var SLDReader = (function (exports, Style, Icon, Fill, Stroke, Circle, RegularSh
         value = childValues.join('');
       }
     } else if (expression.type === 'function') {
+      //TODO: shortcut maken als function 'dimension' heet en feature een RenderFeature is.
       const func = getFunction(expression.name);
       if (!func) {
         value = expression.fallbackValue;
@@ -3236,9 +3237,12 @@ var SLDReader = (function (exports, Style, Icon, Fill, Stroke, Circle, RegularSh
     if (typeof feature.getGeometry !== 'function') {
       return null;
     }
-    const geom = feature.getGeometry();
+    let geom = feature.getGeometry();
     if (!geom) {
       return null;
+    }
+    if (geom instanceof RenderFeature) {
+      geom = RenderFeature.toGeometry(geom);
     }
     let pointStyle = null;
     const geomType = geom.getType();
@@ -3279,9 +3283,12 @@ var SLDReader = (function (exports, Style, Icon, Fill, Stroke, Circle, RegularSh
     if (typeof feature.getGeometry !== 'function') {
       return null;
     }
-    const geom = feature.getGeometry();
+    let geom = feature.getGeometry();
     if (!geom) {
       return null;
+    }
+    if (geom instanceof RenderFeature) {
+      geom = RenderFeature.toGeometry(geom);
     }
     let pointStyle = null;
     const geomType = geom.getType();
@@ -3775,4 +3782,4 @@ var SLDReader = (function (exports, Style, Icon, Fill, Stroke, Circle, RegularSh
 
   return exports;
 
-})({}, ol.style.Style, ol.style.Icon, ol.style.Fill, ol.style.Stroke, ol.style.Circle, ol.style.RegularShape, ol.render, ol.geom.Point, ol.geom.LineString, ol.extent, ol.has, ol.geom.Polygon, ol.geom.MultiPolygon, ol.style.Text, ol.geom.MultiPoint);
+})({}, ol.style.Style, ol.style.Icon, ol.style.Fill, ol.style.Stroke, ol.style.Circle, ol.style.RegularShape, ol.render, ol.geom.Point, ol.geom.LineString, ol.extent, ol.has, ol.geom.Polygon, ol.geom.MultiPolygon, ol.style.Text, ol.render.Feature, ol.geom.MultiPoint);

--- a/docs/assets/vector-tile.js
+++ b/docs/assets/vector-tile.js
@@ -27,7 +27,7 @@ const map = new ol.Map({
   view: new ol.View({
     center: [632295, 6793980],
     zoom: 17,
-    maxZoom: 17,
+    maxZoom: 22,
     minZoom: 17,
   }),
   controls: ol.control.defaults.defaults({attribution: false}).extend([attribution]),

--- a/docs/assets/vector-tile.js
+++ b/docs/assets/vector-tile.js
@@ -1,0 +1,70 @@
+/* global ol SLDReader CodeMirror */
+// the xml editor
+const editor = CodeMirror.fromTextArea(document.getElementById('sld'), {
+  lineNumbers: true,
+  lineWrapping: true,
+  mode: 'xml',
+});
+
+// test vector tile layer of zo
+const vtLayer = new ol.layer.VectorTile({
+  source: new ol.source.VectorTile({
+    minZoom: 17,
+    maxZoom: 17,
+    format: new ol.format.MVT(),
+    url: 'https://api.pdok.nl/lv/bgt/ogc/v1/tiles/WebMercatorQuad/{z}/{y}/{x}?f=mvt',
+  }),
+});
+
+const attribution = new ol.control.Attribution({
+  collapsible: false,
+  attributions: 'Vector tile data from <a href="https://www.pdok.nl" target="_blank">www.pdok.nl</a>',
+});
+
+const map = new ol.Map({
+  layers: [vtLayer],
+  target: document.getElementById('olmap'),
+  view: new ol.View({
+    center: [632295, 6793980],
+    zoom: 17,
+    maxZoom: 17,
+    minZoom: 17,
+  }),
+  controls: ol.control.defaults.defaults({attribution: false}).extend([attribution]),
+});
+map.addControl(new ol.control.MousePosition());
+
+/**
+ * @param {object} vector layer
+ * @param {string} text the xml text
+ * apply sld
+ */
+function applySLD(vectorLayer, text) {
+  const sldObject = SLDReader.Reader(text);
+  // for debugging
+  window.sldObject = sldObject;
+  const sldLayer = SLDReader.getLayer(sldObject);
+  const style = SLDReader.getStyle(sldLayer);
+  const featureTypeStyle = style.featuretypestyles[0];
+
+  vtLayer.setStyle(
+    SLDReader.createOlStyleFunction(featureTypeStyle, {
+      imageLoadedCallback: () => {
+        // Signal OpenLayers to redraw the layer when an image icon has loaded.
+        // On redraw, the updated symbolizer with the correct image scale will be used to draw the icon.
+        vectorLayer.changed();
+      },
+    })
+  );
+}
+
+fetch('assets/sld-vector-tile.xml')
+  .then(response => response.text())
+  .then(text => editor.setValue(text));
+
+/**
+ * update map if sld is edited
+ */
+editor.on('change', cm => {
+  applySLD(vtLayer, cm.getValue());
+});

--- a/docs/vector-tile.html
+++ b/docs/vector-tile.html
@@ -1,0 +1,23 @@
+---
+layout: default
+title: Vector tile styling
+nav_order: 8
+---
+<div class="row">
+  <div class="col-md-12">
+    <h1>Vector tile styling</h1>
+    <p><a href="assets/vector-tile.js">View code</a></p>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-6">
+    <div id="olmap"></div>
+  </div>
+  <div class="col-md-6">
+    <textarea id="sld"></textarea>
+  </div>
+</div>
+</div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.41.0/codemirror.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.41.0/mode/xml/xml.min.js"></script>
+<script src="assets/vector-tile.js"></script>

--- a/olGlobals.mjs
+++ b/olGlobals.mjs
@@ -2,6 +2,7 @@
 // Make sure to map every ol/something/else used in the source code to the corresponding ol.something.Else standalone version.
 const olGlobals = {
   'ol/render': 'ol.render',
+  'ol/render/Feature': 'ol.render.Feature',
   'ol/extent': 'ol.extent',
   'ol/has': 'ol.has',
   'ol/style/Style': 'ol.style.Style',

--- a/src/functions/builtins/index.js
+++ b/src/functions/builtins/index.js
@@ -1,4 +1,4 @@
-import { asString } from '../helpers';
+import { asString, dimensionFromGeometryType } from '../helpers';
 import { registerFunction } from '../index';
 
 // The functions below are taken from the Geoserver function list.
@@ -148,21 +148,10 @@ function geometryType(olGeometry) {
  * @returns {number} The dimension of the geometry. Will return -1 for GeometryCollection or unknown type.
  */
 function dimension(olGeometry) {
-  switch (geometryType(olGeometry)) {
-    case 'Point':
-    case 'MultiPoint':
-      return 0;
-    case 'LineString':
-    case 'LinearRing':
-    case 'Circle':
-    case 'MultiLineString':
-      return 1;
-    case 'Polygon':
-    case 'MultiPolygon':
-      return 2;
-    default:
-      return -1;
+  if (!olGeometry) {
+    return -1;
   }
+  return dimensionFromGeometryType(olGeometry.getType());
 }
 
 /**

--- a/src/functions/builtins/index.js
+++ b/src/functions/builtins/index.js
@@ -145,7 +145,7 @@ function geometryType(olGeometry) {
  * Get the dimension of a geometry. Multipart geometries will return the dimension of their separate parts.
  * @private
  * @param {ol/geom/x} olGeometry OpenLayers Geometry instance.
- * @returns {number} The dimension of the geometry. Will return 0 for GeometryCollection or unknown type.
+ * @returns {number} The dimension of the geometry. Will return -1 for GeometryCollection or unknown type.
  */
 function dimension(olGeometry) {
   switch (geometryType(olGeometry)) {
@@ -161,7 +161,7 @@ function dimension(olGeometry) {
     case 'MultiPolygon':
       return 2;
     default:
-      return 0;
+      return -1;
   }
 }
 

--- a/src/functions/helpers.js
+++ b/src/functions/helpers.js
@@ -24,3 +24,28 @@ export function asString(input) {
       return inputType;
   }
 }
+
+/**
+ * Maps geometry type string to the dimension of a geometry.
+ * Multipart geometries will return the dimension of their separate parts.
+ * @private
+ * @param {string} geometryType OpenLayers Geometry type name.
+ * @returns {number} The dimension of the geometry. Will return -1 for GeometryCollection or unknown type.
+ */
+export function dimensionFromGeometryType(geometryType) {
+  switch (geometryType) {
+    case 'Point':
+    case 'MultiPoint':
+      return 0;
+    case 'LineString':
+    case 'LinearRing':
+    case 'Circle':
+    case 'MultiLineString':
+      return 1;
+    case 'Polygon':
+    case 'MultiPolygon':
+      return 2;
+    default:
+      return -1;
+  }
+}

--- a/src/olEvaluator.js
+++ b/src/olEvaluator.js
@@ -6,8 +6,10 @@
  * @private
  */
 
+import RenderFeature from 'ol/render/Feature';
 import { METRES_PER_FOOT, UOM_FOOT, UOM_METRE } from './constants';
 import { getFunction } from './functions';
+import { dimensionFromGeometryType } from './functions/helpers';
 
 /**
  * Check if an expression depends on feature properties.
@@ -110,6 +112,14 @@ export default function evaluate(
       }
       value = childValues.join('');
     }
+  } else if (
+    expression.type === 'function' &&
+    expression.name === 'dimension' &&
+    feature instanceof RenderFeature
+  ) {
+    // Special shortcut for the dimension function when used on a RenderFeature (vector tiles),
+    // which ignores the geometry name parameter and directly outputs the dimension.
+    value = dimensionFromGeometryType(feature.getType());
   } else if (expression.type === 'function') {
     const func = getFunction(expression.name);
     if (!func) {

--- a/src/styles/linePointStyle.js
+++ b/src/styles/linePointStyle.js
@@ -1,3 +1,5 @@
+import { toGeometry } from 'ol/render/Feature';
+import RenderFeature from 'ol/render/Feature';
 import Point from 'ol/geom/Point';
 import MultiPoint from 'ol/geom/MultiPoint';
 
@@ -18,9 +20,13 @@ function getLinePointStyle(symbolizer, feature, context) {
     return null;
   }
 
-  const geom = feature.getGeometry();
+  let geom = feature.getGeometry();
   if (!geom) {
     return null;
+  }
+
+  if (geom instanceof RenderFeature) {
+    geom = toGeometry(geom);
   }
 
   let pointStyle = null;

--- a/src/styles/polygonPointStyle.js
+++ b/src/styles/polygonPointStyle.js
@@ -1,3 +1,5 @@
+import { toGeometry } from 'ol/render/Feature';
+import RenderFeature from 'ol/render/Feature';
 import Point from 'ol/geom/Point';
 import MultiPoint from 'ol/geom/MultiPoint';
 
@@ -29,9 +31,13 @@ function getPolygonPointStyle(symbolizer, feature, context) {
     return null;
   }
 
-  const geom = feature.getGeometry();
+  let geom = feature.getGeometry();
   if (!geom) {
     return null;
+  }
+
+  if (geom instanceof RenderFeature) {
+    geom = toGeometry(geom);
   }
 
   let pointStyle = null;


### PR DESCRIPTION
Fix bugs and crashes when applying a generated style function to a vector tile layer, which uses RenderFeature instead of Feature internally.