### PR TITLE
Handle multiple font-family parameters

### DIFF
--- a/docs/assets/sldreader-standalone.js
+++ b/docs/assets/sldreader-standalone.js
@@ -1,4 +1,4 @@
-/* Version: 0.7.1 - August 7, 2025 15:59:15 */
+/* Version: 0.7.1 - August 13, 2025 10:40:01 */
 var SLDReader = (function (exports, RenderFeature, Style, Icon, Fill, Stroke, Circle, RegularShape, render, Point, color, colorlike, IconImageCache, ImageStyle, dom, IconImage, LineString, extent, has, Polygon, MultiPolygon, Text, MultiPoint) {
   'use strict';
 
@@ -639,7 +639,24 @@ var SLDReader = (function (exports, RenderFeature, Style, Icon, Fill, Stroke, Ci
         simplifiedValue = parseFloat(simplifiedValue);
       }
     }
-    obj[propertyName] = simplifiedValue;
+
+    // Special handling for font-family style property.
+    // This property can be present more than once, and should be turned into a comma-separated string.
+    if (typeof simplifiedValue === 'string' && propertyName === 'fontFamily') {
+      // Add quotes to font family if necessary.
+      let fontFamily = simplifiedValue;
+      if (/[^\w-]|\d/.test(fontFamily)) {
+        fontFamily = `"${fontFamily}"`;
+      }
+      if (!obj.fontFamily) {
+        obj.fontFamily = fontFamily;
+      } else if (typeof obj.fontFamily === 'string') {
+        // Append font family to existing font family (as long as it's a static property).
+        obj.fontFamily += `, ${fontFamily}`;
+      }
+    } else {
+      obj[propertyName] = simplifiedValue;
+    }
   }
   function addNumericParameterValueProp(node, obj, prop) {
     let options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};

--- a/src/Reader/index.js
+++ b/src/Reader/index.js
@@ -148,7 +148,9 @@ function addExternalGraphicProp(node, obj, prop, options) {
       externalgraphic.onlineresource = `data:${externalgraphic.format || ''};base64,${externalgraphic.inlinecontent}`;
       delete externalgraphic.inlinecontent;
     } else if (externalgraphic.encoding?.indexOf('xml') > -1) {
-      const encodedXml = window.encodeURIComponent(externalgraphic.inlinecontent);
+      const encodedXml = window.encodeURIComponent(
+        externalgraphic.inlinecontent
+      );
       externalgraphic.onlineresource = `data:image/svg+xml;utf8,${encodedXml}`;
       delete externalgraphic.inlinecontent;
     }
@@ -410,7 +412,24 @@ function addParameterValueProp(node, obj, prop, options = {}) {
     }
   }
 
-  obj[propertyName] = simplifiedValue;
+  // Special handling for font-family style property.
+  // This property can be present more than once, and should be turned into a comma-separated string.
+  if (typeof simplifiedValue === 'string' && propertyName === 'fontFamily') {
+    // Add quotes to font family if necessary.
+    let fontFamily = simplifiedValue;
+    if (/[^\w-]|\d/.test(fontFamily)) {
+      fontFamily = `"${fontFamily}"`;
+    }
+
+    if (!obj.fontFamily) {
+      obj.fontFamily = fontFamily;
+    } else if (typeof obj.fontFamily === 'string') {
+      // Append font family to existing font family (as long as it's a static property).
+      obj.fontFamily += `, ${fontFamily}`;
+    }
+  } else {
+    obj[propertyName] = simplifiedValue;
+  }
 }
 
 function addNumericParameterValueProp(node, obj, prop, options = {}) {

--- a/test/Reader.test.js
+++ b/test/Reader.test.js
@@ -193,7 +193,7 @@ describe('Reads xml sld 11', () => {
     expect(symbolizer).to.be.an.instanceof(Object);
     expect(symbolizer.font).to.be.an.instanceof(Object);
     expect(symbolizer.font.styling).to.be.an.instanceof(Object);
-    expect(symbolizer.font.styling.fontFamily).to.equal('Noto Sans');
+    expect(symbolizer.font.styling.fontFamily).to.equal('"Noto Sans", Arial, sans-serif');
   });
   it('rule textsymbolizer has fill', () => {
     const rule =

--- a/test/data/test11.sld.js
+++ b/test/data/test11.sld.js
@@ -74,6 +74,8 @@ export const sld11 = `<?xml version="1.0" encoding="UTF-8"?>
             </se:Label>
             <se:Font>
               <se:SvgParameter name="font-family">Noto Sans</se:SvgParameter>
+              <se:SvgParameter name="font-family">Arial</se:SvgParameter>
+              <se:SvgParameter name="font-family">sans-serif</se:SvgParameter>
               <se:SvgParameter name="font-size">13</se:SvgParameter>
             </se:Font>
             <se:LabelPlacement>


### PR DESCRIPTION
Fixes bug where only the last of multiple `font-family` Svg/Css params was added as `fontFamily` style property.

They are now turned into a comma-separated font family string.